### PR TITLE
Add workflow to deploy to GitHub pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  # Allows you to run this workflow manually from the Actions tab on GitHub
+  workflow_dispatch:
+
+# Allow this job to clone the repo and create a page deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install, build, and upload your site output
+        uses: withastro/action@v2
+        with:
+          path: site
+          node-version: 20
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -4,6 +4,9 @@ import icon from "astro-icon";
 
 // https://astro.build/config
 export default defineConfig({
+  site: "https://accessiblecommunity.github.io",
+  base: "fixable",
+  trailingSlash: "always",
   server: {
     host: true,
     port: 4323

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -7,7 +7,7 @@ import logo from "@/assets/images/mbt-logo.png";
 
 <header>
   <div class="logo">
-    <a href="/"><Image
+    <a href={import.meta.env.BASE_URL}><Image
         src={logo}
         alt="Museum of Broken Things"
         width="75"

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -18,7 +18,7 @@ import Navigation from "@/components/Navigation.astro";
     <meta charset="UTF-8" />
     <meta name="description" content="Astro description" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href=`${import.meta.env.BASE_URL}favicon.svg` />
     <meta name="generator" content={Astro.generator} />
     <title>{title} - Fixable</title>
   </head>

--- a/site/src/lib/nav-links.ts
+++ b/site/src/lib/nav-links.ts
@@ -1,9 +1,12 @@
 export const navLinks = [
-  { href: "/collections", name: "Collections" },
-  { href: "/tour", name: "Take a Tour" },
-  { href: "/news", name: "In the News" },
-  { href: "/gift-shop", name: "Gift Shop" },
-  { href: "/map", name: "Museum Map" },
-  { href: "/volunteer", name: "Volunteer" },
-  { href: "/about", name: "About" },
-];
+  { href: "collections/", name: "Collections" },
+  { href: "tour/", name: "Take a Tour" },
+  { href: "news/", name: "In the News" },
+  { href: "gift-shop/", name: "Gift Shop" },
+  { href: "map/", name: "Museum Map" },
+  { href: "volunteer/", name: "Volunteer" },
+  { href: "about/", name: "About" },
+].map(({href, name}) => ({
+  href: `${import.meta.env.BASE_URL}${href}`,
+  name
+}));

--- a/site/src/pages/collections/index.astro
+++ b/site/src/pages/collections/index.astro
@@ -17,7 +17,7 @@ const tags = uniq(flattenDeep(nestedTags)).sort();
       tags.map((tag) => (
         <li class="list-group-item">
           <a
-            href={`/collections/${tag}`}
+            href={`${tag}/`}
             set:text={tagTitleOverrides[tag] || startCase(tag)}
           />
         </li>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,19 +8,19 @@ const collections = [
     title: "Toys & Dolls",
     description: "They can dance in the dark.",
     imageItem: await getEntry("collection", "blue-bear"),
-    href: "/collections/toys",
+    tag: "toys",
   },
   {
     title: "Dishes",
     description: "Did someone say dinner?",
     imageItem: await getEntry("collection", "blue-dish"),
-    href: "/collections/dishes",
+    tag: "dishes",
   },
   {
     title: "Containers",
     description: "These won't hold water",
     imageItem: await getEntry("collection", "clay-jug"),
-    href: "/collections/containers",
+    tag: "containers",
   },
 ];
 ---
@@ -29,7 +29,7 @@ const collections = [
   <h2 class="card-header bg-black text-light">Explore our Collections</h2>
   <div class="cards">
     {
-      collections.map(({ description, href, imageItem, title }) => (
+      collections.map(({ description, imageItem, tag, title }) => (
         <CollectionCard
           title={title}
           description={description}
@@ -37,7 +37,7 @@ const collections = [
           height="200"
           style="max-height: 60rem; max-width: 60rem;"
         >
-          <a slot="footer" class="btn btn-primary w-100" {href}>
+          <a slot="footer" class="btn btn-primary w-100" href={`collections/${tag}/`}>
             Explore
           </a>
         </CollectionCard>
@@ -45,7 +45,7 @@ const collections = [
     }
   </div>
   <div class="cards-footer">
-    <a href="/collections">Our collections &rArr;</a>
+    <a href="collections/">Our collections &rArr;</a>
   </div>
   <dl slot="wcag2">
     <dt>Non-Text Content</dt>


### PR DESCRIPTION
This uses Astro's GitHub action and workflow template to deploy the build to GitHub pages.

## Changes

- Updated Astro config to include `site` and `base` to support the GitHub pages destination
- Updated hrefs to reference `import.meta.env.BASE_URL` where absolute URLs are necessary (e.g. within `Layout.astro` and isolated components)
- Updated hrefs to use relative URLs when possible (e.g. within specific `pages`)
  - Set `trailingSlash: "always"` and updated all links to include trailing slashes, for predictable relative hrefs (AFAIK github pages already auto-suffixes with a trailing slash, but I'm being safe for any potential future switch)

## Notes

Example deployment from testing on my fork: https://kfranqueiro.github.io/fixable/

The built version can be previewed locally using `npm run build` followed by `npm run astro preview`.

I have configured GitHub pages to deploy specifically from actions only, which AFAIK produces no gh-pages branch (which is good - prevents assets from piling up across revisions and bloating local checkouts).