### PR TITLE
Add LaxImage component and use for CollectionCard

### DIFF
--- a/site/src/components/CollectionCard.astro
+++ b/site/src/components/CollectionCard.astro
@@ -1,11 +1,14 @@
 ---
+import type { LocalImageProps } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
+import { pick } from "lodash-es";
+import LaxImage from "./LaxImage.astro";
 
-type Props = {
+const imagePropNames = ["height", "width", "sizes", "widths"] as const;
+
+type Props = Pick<LocalImageProps, typeof imagePropNames[number]> & {
   class?: string;
   style?: string;
-  height?: `${number}` | number;
-  width?: `${number}` | number;
 } & (
   | {
       description: string;
@@ -15,7 +18,8 @@ type Props = {
   | { item: CollectionEntry<"collection"> }
 );
 
-const { class: extraClasses, height, style, width } = Astro.props;
+const { class: extraClasses, style } = Astro.props;
+const imageProps = pick(Astro.props, imagePropNames);
 
 const Content =
   "item" in Astro.props ? (await Astro.props.item.render()).Content : null;
@@ -26,19 +30,11 @@ const { description, image, title } =
 <div class:list={["card", extraClasses]} {style}>
   <div class={image.vertical ? "vertical" : "horizontal"}>
     <div class="image-container">
-      {
-        /* Notes:
-        - object-fit precludes use of Image component due to its auto-setting size attributes
-        - Image component also won't allow intentionally omitting alt for failures
-        - image.src is a full Astro image schema object; could use a better name?
-      */
-      }
-      <img
-        src={image.src.src}
-        alt={image.alt || description}
-        height={height}
-        width={width}
+      <LaxImage
+        src={image.src}
+        alt={image.alt || null}
         object-fit="cover"
+        {...imageProps}
       />
     </div>
     <div class="content">
@@ -90,6 +86,10 @@ const { description, image, title } =
     & .content,
     & .image-container {
       width: 50%;
+    }
+
+    img {
+      height: 100%;
     }
   }
 

--- a/site/src/components/LaxImage.astro
+++ b/site/src/components/LaxImage.astro
@@ -1,0 +1,41 @@
+---
+import { getImage, type LocalImageProps } from "astro:assets";
+import { omit } from "lodash-es";
+
+/** @fileoverview
+ * Custom Image component designed for the following edge cases:
+ * - Allows omitting alt text for intentional WCAG failures
+ * - Does not force setting width/height attributes on img,
+ *   to avoid unwanted interference with object-fit
+ * - Still runs through Astro's image optimization function
+ */
+
+type Props = LocalImageProps & {
+  processHeight?: number;
+  processWidth?: number;
+};
+
+const { height, width } = Astro.props;
+
+const image = await getImage({
+  ...Astro.props,
+  ...(typeof height === "string" && { height: parseInt(height) }),
+  ...(typeof width === "string" && { width: parseInt(width) }),
+});
+
+const attributes =
+  "object-fit" in Astro.props
+    ? {
+        // Only include width/height if they were originally specified
+        ...omit(image.attributes, "height", "width"),
+        height,
+        width,
+      }
+    : image.attributes;
+---
+
+<img
+  src={image.src}
+  {...attributes}
+  {...image.srcSet.values.length && { srcset: image.srcSet.attribute }}
+/>

--- a/site/src/pages/collections/[tag].astro
+++ b/site/src/pages/collections/[tag].astro
@@ -39,7 +39,7 @@ const collection = sortBy(
   <div class="container">
     <h2>{title}</h2>
     <div class="cards">
-      {collection.map((item) => <CollectionCard {item} />)}
+      {collection.map((item) => <CollectionCard {item} widths={[1200]} />)}
     </div>
   </div>
 </Layout>


### PR DESCRIPTION
This brings CollectionCard back to roughly its earlier behavior, but without forcibly distorting images nor forcing specification of `alt` (since I'm guessing we'll want to intentionally omit it for a failure at some point).

I had previously removed usage of the `Image` component because it forces specification of alt in the input and width/height in its output. The problem with removing that is it balloons image asset sizes, because the source assets are huge. This PR introduces a `LaxImage` component that reproduces most of `Image`'s behavior, without those limitations.

I also added a missing style to CollectionCard to fix the side-by-side layout for tall images (e.g. the 2nd item on the toys page).