### PR TITLE
Add meta homepage; replace expandable footer with link

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,29 +1,25 @@
 ---
-interface Crumbs {
-  name: String;
-  href: URL;
-}
-
-interface Props {
-  crumbs?: Array<Crumbs>;
-}
-
 import { Image } from "astro:assets";
 import logo from "@/assets/images/mbt-logo.png";
 
+import { slugifyPath } from "@/lib/meta";
 import { navLinks } from "@/lib/nav-links";
 
+const metaAnchor = slugifyPath(Astro.url.pathname.replace(import.meta.env.BASE_URL, ""));
 ---
 
 <footer>
   <div class="links">
     {navLinks.map(({ name, href }) => <a {href}>{name}</a>)}
   </div>
-  <div>
+  <div class="about">
     <Image src={logo} alt="Museum of Broken Things" width="250" height="250" />
-    <p>
-      The Museum of Broken Things is brought to you by Accessible Community, with
+    <p class="attribution">
+      The Museum of Broken Things is brought to you by Accessible Community and W3C, with
       help from <a href="https://unsplash.com/">Unsplash</a> and various AI chatbots.
+    </p>
+    <p>
+      <a href={`${import.meta.env.BASE_URL}#${metaAnchor}`}>What's wrong with this page?</a>
     </p>
   </div>  
 </footer>
@@ -42,13 +38,16 @@ import { navLinks } from "@/lib/nav-links";
     & a:hover {
       color: var(--gold-vivid-200);
     }
+  }
 
-    & p {
-      font-size: 70%;
-      text-align: center;
-      min-width: 250px;
-      max-width: 250px;    
-    }
+  .about {
+    text-align: center;
+  }
+
+  .attribution {
+    font-size: 70%;
+    min-width: 250px;
+    max-width: 250px;    
   }
 
   .links a {

--- a/site/src/components/meta/MetaFailureSection.astro
+++ b/site/src/components/meta/MetaFailureSection.astro
@@ -1,0 +1,50 @@
+---
+/** @fileoverview Component that handles some boilerplate for each failure section in the top page. */
+
+interface Props {
+  /** Path to the page being described, e.g. museum/, museum/login/, etc. */
+  href: string;
+  title: string;
+}
+
+const { href, title } = Astro.props;
+---
+
+<section id={href.replace(/\//g, "-").replace(/-$/, "")}>
+  <h3><a href={`${import.meta.env.BASE_URL}${href}`}>{title}</a></h3>
+  {
+    Astro.slots.wcag2 && (
+      <>
+        <h4>WCAG 2</h4>
+        <slot name="wcag2" />
+      </>
+    )
+  }
+  {
+    Astro.slots.wcag3 && (
+      <>
+        <h4>WCAG 3</h4>
+        <slot name="wcag3" />
+      </>
+    )
+  }
+</section>
+
+<script>
+  if (location.hash)
+    document.getElementById(location.hash.slice(1))?.classList.add("destination");
+</script>
+
+<style>
+  section {
+    padding: 0 1rem;
+  }
+
+  .destination {
+    background-color: var(--gold-vivid-100);
+  }
+
+  dt {
+    font-weight: bold;
+  }
+</style>

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -1,26 +1,25 @@
 ---
-interface Props {
-  title: string;
-}
-
-const { title } = Astro.props;
-
 import "@/assets/styles/styles.css";
 
 import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
 import Navigation from "@/components/Navigation.astro";
+
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
 ---
 
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="description" content="Astro description" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href=`${import.meta.env.BASE_URL}favicon.svg` />
     <meta name="generator" content={Astro.generator} />
-    <title>{title} - Fixable</title>
+    <title>{title} - The Museum of Broken Things</title>
   </head>
   <body>
     <a class="visually-hidden skip-link" href="#main">Skip to the main content</a>
@@ -32,47 +31,5 @@ import Navigation from "@/components/Navigation.astro";
 			</main>
 		</div>
     <Footer />
-    {
-      (Astro.slots.wcag2 || Astro.slots.wcag3) && (
-        <section>
-          <h2 class="visually-hidden">Page explainer</h2>
-          <details>
-            <summary>What's wrong with this page?</summary>
-            <div>
-							<div>
-								<h3>WCAG 2 issues</h3>
-								<slot name="wcag2">
-									<p>No issues.</p>
-								</slot>
-							</div>
-							<div>
-								<h3>WCAG 3 issues</h3>
-								<slot name="wcag3">
-									<p>No issues.</p>
-								</slot>
-							</div>
-            </div>
-          </details>
-        </section>
-      )
-    }
   </body>
 </html>
-
-<style>
-  details > div {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: calc(var(--ms0) * 1rem);
-    padding: calc(var(--ms0) * 1rem);
-  }
-  summary {
-    background: pink;
-    font-size: calc(var(--ms3) * 1rem);
-    padding: calc(var(--ms0) * 1rem);
-  }
-
-  dt {
-    font-weight: bold;
-  }
-</style>

--- a/site/src/layouts/MetaLayout.astro
+++ b/site/src/layouts/MetaLayout.astro
@@ -1,0 +1,33 @@
+---
+/** @fileoverview Layout for meta (top-level, non-museum) pages. */
+
+import "@/assets/styles/styles.css";
+
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href=`${import.meta.env.BASE_URL}favicon.svg`
+    />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title} - Fixable</title>
+  </head>
+  <body>
+    <div class="wrapper">
+      <main id="main">
+        <slot />
+      </main>
+    </div>
+  </body>
+</html>

--- a/site/src/lib/meta.ts
+++ b/site/src/lib/meta.ts
@@ -1,0 +1,2 @@
+export const slugifyPath = (path: string) =>
+  path.replace(/\//g, "-").replace(/^-/, "").replace(/-$/, "");

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,0 +1,86 @@
+---
+import MetaFailureSection from "@/components/meta/MetaFailureSection.astro";
+import MetaLayout from "@/layouts/MetaLayout.astro";
+---
+
+<MetaLayout title="General Information">
+  <h1>General Information</h1>
+  <section id="about-this-site">
+    <h2>About The Museum of Broken Things</h2>
+    <p>
+      This site is designed to demonstrate a wide range of accessibility
+      failures, for teaching and assessment purposes.
+    </p>
+  </section>
+
+  <section id="summary-of-failures">
+    <h2>Summary of failures</h2>
+    <p>
+      This section provides a breakdown of failures, organized on a per-page
+      basis.
+    </p>
+
+    {
+      import.meta.env.DEV && (
+        <p id="dev-error" class="error" hidden>
+          The section specified in the hash does not exist. Check for typos in
+          href, or make sure to add it to this page.
+        </p>
+      )
+    }
+
+    <MetaFailureSection href="museum/" title="Home">
+      <dl slot="wcag2">
+        <dt>1.4.3: Contrast (Minimum)</dt>
+        <dd>
+          Text overlaying images in the carousel does not include a background
+          to guarantee contrast.
+        </dd>
+        <dt>2.2.2: Pause, Stop, Hide</dt>
+        <dd>
+          The carousel does not include controls to stop moving and updating.
+        </dd>
+      </dl>
+    </MetaFailureSection>
+
+    <MetaFailureSection href="museum/login/" title="Sign In">
+      <dl slot="wcag2">
+        <dt>1.4.3: Contrast (Minimum)</dt>
+        <dd>Placeholder text does not meet the minimum contrast ratio.</dd>
+        <dt>3.3.2: Labels or Instructions</dt>
+        <dd>Form inputs have no labels.</dd>
+      </dl>
+    </MetaFailureSection>
+
+    <MetaFailureSection href="museum/volunteer/" title="Volunteer">
+      <dl slot="wcag2">
+        <dt>2.2.6: Timeouts</dt>
+        <dd>
+          The form becomes unsubmittable after a short time period which is not
+          disclosed in advance.
+        </dd>
+      </dl>
+    </MetaFailureSection>
+  </section>
+
+  <section id="acknowledgment">
+    <h2>Acknowledgment</h2>
+    <p>
+      The Museum of Broken Things is brought to you by
+      <a href="https://accessiblecommunity.org/">Accessible Community</a> and the
+      <a href="https://www.w3.org/WAI/about/groups/agwg/"
+        >W3C Accessibility Guidelines Working Group</a
+      >.
+    </p>
+  </section>
+</MetaLayout>
+
+<script>
+  if (
+    import.meta.env.DEV &&
+    location.hash &&
+    !document.getElementById(location.hash.slice(1))
+  ) {
+    document.getElementById("dev-error")!.hidden = false;
+  }
+</script>

--- a/site/src/pages/museum/index.astro
+++ b/site/src/pages/museum/index.astro
@@ -47,27 +47,6 @@ const collections = [
   <div class="cards-footer">
     <a href="collections/">Our collections &rArr;</a>
   </div>
-  <dl slot="wcag2">
-    <dt>Non-Text Content</dt>
-    <dd>
-      The image of the cheese has <code class="language-html">alt</code> text that
-      doesn't accurately describe it.
-    </dd>
-    <dt>Focus Order</dt>
-    <dd>
-      When the modal dialog is opened, focus isn't moved into the modal element.
-    </dd>
-    <dd>
-      When the modal dialog is closed, focus isn't moved onto the element that
-      triggered the the modal to open.
-    </dd>
-  </dl>
-  <dl slot="wcag3">
-    <dt>Some Issue</dt>
-    <dd>Some Description</dd>
-    <dt>Some Other Issue</dt>
-    <dd>Some Other Description</dd>
-  </dl>
 </Layout>
 
 <style>

--- a/site/src/pages/museum/volunteer/index.astro
+++ b/site/src/pages/museum/volunteer/index.astro
@@ -30,10 +30,6 @@ import Layout from "@/layouts/Layout.astro";
     </p>
     <button type="submit">Submit</button>
   </form>
-  <dl slot="wcag2">
-    <dt>2.2.6: Timeouts</dt>
-    <dd>The form becomes unsubmittable after a short time period which is not disclosed in advance.</dd>
-  </dl>
 </Layout>
 
 <script>


### PR DESCRIPTION
This adds a new top-level index page with information about breakages implemented in the Museum site.

It also replaces the expandable section at the bottom of individual pages with a link (for now, possibly a dialog w/ iframe later) pointing to the specific section in the top-level page discussing the page in question.

The top-level page sets up sections with specifically-named IDs (with the help of a reusable component, `MetaFailureSection`) to make this Just Work from individual pages based on their path. If a path does not match to an ID as expected, an error message will be shown in local dev only (not in builds).

Link in museum page footers:

![image](https://github.com/user-attachments/assets/7a97234f-cfbb-4d83-a81c-290d748bde55)

Example when following a link back to a matching section:

![image](https://github.com/user-attachments/assets/4b662e75-8cdb-40b2-8ce3-708fa65e0e93)

Example in dev when the specified hash is not found:

![image](https://github.com/user-attachments/assets/e3a3d962-a316-4105-ad19-97aaec622956)
