### PR TITLE
Implement sign in/out button swap based on stored state

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -4,6 +4,7 @@ import { Icon } from "astro-icon/components";
 import { museumBaseUrl } from "@/lib/constants";
 
 import logo from "@/assets/images/mbt-logo.png";
+import UserControls from "./UserControls.astro";
 ---
 
 <header>
@@ -24,7 +25,7 @@ import logo from "@/assets/images/mbt-logo.png";
         <Icon name="ri:search-line" />
       </button>
     </form>
-    <a class="button" href=`${museumBaseUrl}login/`>Sign In</a>
+    <UserControls />
   </div>
 </header>
 

--- a/site/src/components/UserControls.astro
+++ b/site/src/components/UserControls.astro
@@ -1,0 +1,23 @@
+---
+import { museumBaseUrl } from "@/lib/constants";
+---
+
+<a id="sign-in" class="button" href=`${museumBaseUrl}login/`>Sign In</a>
+<button id="sign-out" type="button" hidden>Sign Out</button>
+
+<script>
+  import { persist, recall } from "@/lib/client/store";
+
+  const signInButton = document.getElementById("sign-in") as HTMLButtonElement;
+  const signOutButton = document.getElementById("sign-out") as HTMLButtonElement;
+
+  signOutButton.addEventListener("click", () => {
+    persist("isLoggedIn", false);
+    location.href = location.href;
+  });
+
+  if (recall("isLoggedIn")) {
+    signInButton.hidden = true;
+    signOutButton.hidden = false;
+  }
+</script>


### PR DESCRIPTION
This is a small follow-up to the persistence added in #9.

When signed in successfully, the sign in button in the header will be replaced with a sign out button via client-side scripting.

Upon clicking sign-out, the logged-in state will be cleared and the current page will be re-navigated (intentionally not using `reload()` since that has potential to repeat signing in).

(If we want a dedicated sign out page that makes the user wait a few seconds, that can be arranged.)