### PR TITLE
Implement prototype gift shop page with functional cart

### DIFF
--- a/site/src/lib/client/store.ts
+++ b/site/src/lib/client/store.ts
@@ -8,6 +8,12 @@ const storage = localStorage;
  * Every property should include .default for upgrade-friendliness.
  */
 const storeSchema = z.object({
+  // Note(ken): This is intentionally under a temporary name
+  // so that any existing values will be cleared when we finalize it
+  cartPrototype: z.record(z.string(), z.object({
+    quantity: z.number().min(1),
+    unitPrice: z.number().min(0.01),
+  })).default({}),
   isLoggedIn: z.boolean().default(false),
 });
 type Store = z.infer<typeof storeSchema>;
@@ -25,7 +31,7 @@ function initStore() {
 const store = initStore();
 
 /** Recalls a single client-side-stored value. */
-export const recall = (key: keyof Store) => store[key];
+export const recall = <K extends keyof Store>(key: K): Store[K] => store[key];
 
 /** Persists a single client-side-stored value. */
 export function persist<K extends keyof Store>(key: K, value: Store[K]) {

--- a/site/src/pages/museum/gift-shop/index.astro
+++ b/site/src/pages/museum/gift-shop/index.astro
@@ -1,7 +1,144 @@
 ---
-import Layout from '@/layouts/Layout.astro';
+import Layout from "@/layouts/Layout.astro";
+import { startCase } from "lodash-es";
+
+// TODO: flesh out products, likely in a content collection;
+// this is temporary to test cart functionality
+const products = {
+  Apparel: {
+    "t-shirt": 17.99,
+    sweatshirt: 27.99,
+    cap: 14.99,
+  },
+  "(Non-broken) Containers": {
+    "water-bottle": 15.99,
+    "coffee-mug": 12.99,
+    "travel-mug": 24.99,
+  },
+  Accessories: {
+    "keychain-charm": 19.99,
+    "sticker-set": 9.99,
+  },
+} as const;
 ---
 
 <Layout title="Gift Shop">
-  <p>This is the gift shop page.</p>
+  <h1>Gift Shop</h1>
+  <div class="container">
+    <div class="products">
+      <h2>Products</h2>
+      {
+        Object.keys(products).map((category) => (
+          <>
+            <h3>{category}</h3>
+            <ul>
+              {Object.entries(products[category]).map(([id, unitPrice]) => (
+                <li>
+                  {startCase(id.replace(/-/g, " "))} (${unitPrice}){" "}
+                  <button id={`${id}-add`} data-price={unitPrice} type="button">
+                    Add to cart
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        ))
+      }
+    </div>
+    <div class="cart">
+      <h2>Cart</h2>
+      <p id="cart-empty">No items in cart.</p>
+      <ul id="cart-list"></ul>
+      <p id="cart-total" hidden></p>
+    </div>
+  </div>
 </Layout>
+
+<script>
+  import startCase from "lodash-es/startCase";
+  import { persist, recall } from "@/lib/client/store";
+
+  const cart = recall("cartPrototype");
+  renderCart();
+
+  function renderCart() {
+    const listEl = document.getElementById("cart-list") as HTMLUListElement;
+    listEl.innerHTML = "";
+
+    const totalEl = document.getElementById(
+      "cart-total"
+    ) as HTMLParagraphElement;
+
+    const entries = Object.entries(cart);
+    document.getElementById("cart-empty")!.hidden = !!entries.length;
+    totalEl.hidden = !entries.length;
+
+    let total = 0;
+    for (const [id, { quantity, unitPrice }] of entries) {
+      const removeEl = document.createElement("button");
+      removeEl.id = `${id}-remove`;
+      removeEl.type = "button";
+      removeEl.textContent = "Remove";
+
+      const itemEl = document.createElement("li");
+      itemEl.textContent = `${startCase(id.replace(/-/g, " "))} (${quantity} × $${unitPrice}) `;
+      itemEl.appendChild(removeEl);
+
+      listEl.appendChild(itemEl);
+
+      total += quantity * unitPrice;
+    }
+
+    totalEl.innerHTML = `<strong>Total: $${total.toFixed(2)}</strong>`;
+  }
+
+  document.body.addEventListener("click", (event) => {
+    const buttonEl = event.target as HTMLButtonElement;
+    if (buttonEl.tagName !== "BUTTON") return;
+    const match = /^(.*)-(add|remove)$/.exec(buttonEl.id);
+    if (!match || !match[1]) return;
+
+    const cartProduct = cart[match[1]];
+    if (cartProduct) {
+      cartProduct.quantity += match[2] === "add" ? 1 : -1;
+      if (cartProduct.quantity < 1) delete cart[match[1]];
+    } else if (match[2] === "add") {
+      cart[match[1]] = { quantity: 1, unitPrice: +buttonEl.dataset.price! };
+    }
+
+    renderCart();
+    persist("cartPrototype", cart);
+  });
+</script>
+
+<style>
+  .container {
+    display: flex;
+    gap: calc(1rem * var(--ms15));
+  }
+
+  .products {
+    flex-grow: 1;
+  }
+
+  .cart {
+    width: 20rem;
+  }
+
+  ul {
+    list-style-type: none;
+    padding: 0;
+
+    /* This needs to be nested to reach programmatically-generated list items */
+    li {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: calc(1rem * var(--ms-2)) 0;
+
+      &:not(:last-child) {
+        border-bottom: 1px solid var(--hairline);
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
This creates some minimally-styled markup on the gift shop page so I could build and test cart functionality.

This will presumably be spread across multiple pages once we have more fleshed-out data and designs for it.

Note: This all uses vanilla JS; I carried forward the assumption that we want to avoid libraries. I presume that the cart is likely to be the most client-side-scripting-heavy feature of the site, and this still isn't a terrible amount of code as-is, though it might be more ergonomic with e.g. a Preact island. We can make a call on that, or at least rearrange cart functions into a dedicated TS file if that ends up making sense, once we understand how the fully-structured gift shop will work.