### PR TITLE
Add checkout flow

### DIFF
--- a/site/src/components/Fixable.astro
+++ b/site/src/components/Fixable.astro
@@ -21,4 +21,6 @@ type Props<Tag extends HTMLTag> = Polymorphic<{ as: Tag }> & {
 const { as: Tag, broken, fixed, ...props } = Astro.props;
 ---
 
-<Tag {...props} {...(mode === "broken" ? broken : fixed)} />
+<Tag {...props} {...(mode === "broken" ? broken : fixed)}>
+  <slot />
+</Tag>

--- a/site/src/components/Timeout.astro
+++ b/site/src/components/Timeout.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * @fileoverview Component which disables all form inputs in the main region and shows a message
+ * after a given timeout.
+ */
+
+interface Props {
+  /** Timeout duration, in milliseconds */
+  duration?: number;
+}
+
+const { duration = 30000 } = Astro.props;
+---
+
+<p id="timeout-message" data-duration={duration} hidden>
+  <slot />
+</p>
+
+<script>
+  const messageEl = document.getElementById("timeout-message") as HTMLParagraphElement;
+  const form = document.querySelector("main form") as HTMLFormElement;
+  const inputSelectors = ["input", "select", "button"] as const;
+
+  setTimeout(() => {
+    messageEl.hidden = false;
+    inputSelectors.forEach((selector) =>
+      form.querySelectorAll(selector).forEach((el) => (el.disabled = true))
+    );
+  }, +messageEl.dataset.duration!);
+</script>

--- a/site/src/components/cart/CartInventory.astro
+++ b/site/src/components/cart/CartInventory.astro
@@ -1,0 +1,57 @@
+---
+interface Props {
+  includeRemove?: boolean;
+}
+
+const { includeRemove } = Astro.props;
+---
+
+<table>
+  <thead>
+    <tr>
+      <th>Product</th>
+      <th>Unit Price</th>
+      <th>Quantity</th>
+      {includeRemove && <th data-actions="">Actions</th>}
+    </tr>
+  </thead>
+  <tbody id="cart-tbody"></tbody>
+</table>
+
+<script>
+  import {
+    handleCartInteractions,
+    renderCartInventory,
+  } from "@/lib/client/cart";
+  import { onStoreChange } from "@/lib/client/store";
+
+  handleCartInteractions();
+
+  onStoreChange("cartPrototype", (cart) =>
+    renderCartInventory(
+      cart,
+      "cart-tbody",
+      !!document.querySelector("[data-actions]")
+    )
+  );
+</script>
+
+<style>
+  /* Nesting is required for styles to reach programmatically-added elements */
+  table {
+    th,
+    td {
+      padding: calc(1rem * var(--ms-5));
+    }
+
+    td {
+      border-top: 1px solid var(--hairline);
+    }
+
+    th:not(:first-child),
+    td:not(:first-child) {
+      border-left: 1px solid var(--hairline);
+      text-align: center;
+    }
+  }
+</style>

--- a/site/src/components/cart/CartStatus.astro
+++ b/site/src/components/cart/CartStatus.astro
@@ -1,0 +1,31 @@
+---
+import { museumBaseUrl } from "@/lib/constants";
+---
+
+<p>
+  Your cart contains <strong id="cart-total-items">0 items</strong>, totaling <strong
+    id="cart-total-cost">$0.00</strong
+  >.
+</p>
+{
+  !Astro.url.pathname.endsWith("/checkout/") && (
+    <p id="cart-proceed" hidden>
+      <a href={`${museumBaseUrl}gift-shop/checkout/`}>Proceed to Checkout</a>
+    </p>
+  )
+}
+
+<script>
+  import { computeTotals } from "@/lib/client/cart";
+  import { onStoreChange } from "@/lib/client/store";
+
+  onStoreChange("cartPrototype", (cart) => {
+    const { totalCost, totalItems } = computeTotals(cart);
+    document.getElementById("cart-total-items")!.textContent =
+      `${totalItems} item${totalItems === 1 ? "" : "s"}`;
+    document.getElementById("cart-total-cost")!.textContent =
+      `$${totalCost.toFixed(2)}`;
+    document.getElementById("cart-proceed")!.hidden =
+      Object.keys(cart).length === 0;
+  });
+</script>

--- a/site/src/components/meta/MetaFailureSection.astro
+++ b/site/src/components/meta/MetaFailureSection.astro
@@ -12,6 +12,7 @@ const { href, title } = Astro.props;
 
 <section id={href.replace(/\//g, "-").replace(/-$/, "")}>
   <h3><a href={`${import.meta.env.BASE_URL}${href}`}>{title}</a></h3>
+  <slot />
   {
     Astro.slots.wcag2 && (
       <>

--- a/site/src/lib/client/cart.ts
+++ b/site/src/lib/client/cart.ts
@@ -1,0 +1,76 @@
+import { startCase } from "lodash-es";
+import { persist, recall, type Store } from "./store";
+
+/** Returns aggregated statistics about cart contents. */
+export function computeTotals(cart: Store["cartPrototype"]) {
+  let totalItems = 0;
+  let totalCost = 0;
+  for (const { quantity, unitPrice } of Object.values(cart)) {
+    totalItems += quantity;
+    totalCost += unitPrice * quantity;
+  }
+  return { totalCost, totalItems };
+}
+
+let isHandlingInteractions = false;
+/**
+ * Hooks up a document-level click listener for cart add/remove operations.
+ * Controls are expected to be buttons beginning with a product ID and
+ * ending with -add/-remove. Add controls should also define data-price.
+ * (These expectations are likely to change upon developing full product pages.)
+ */
+export function handleCartInteractions() {
+  if (isHandlingInteractions) return; // Only hook up once per page
+
+  document.addEventListener("click", (event) => {
+    const buttonEl = event.target as HTMLButtonElement;
+    if (buttonEl.tagName !== "BUTTON") return;
+    const match = /^(.*)-(add|remove)$/.exec(buttonEl.id);
+    if (!match || !match[1]) return;
+
+    const cart = recall("cartPrototype");
+    const cartProduct = cart[match[1]];
+    if (cartProduct) {
+      cartProduct.quantity += match[2] === "add" ? 1 : -1;
+      if (cartProduct.quantity < 1) delete cart[match[1]];
+    } else if (match[2] === "add") {
+      cart[match[1]] = { quantity: 1, unitPrice: +buttonEl.dataset.price! };
+    }
+
+    persist("cartPrototype", cart);
+  });
+
+  isHandlingInteractions = true;
+}
+
+/**
+ * Renders the contents of the gift shop cart (client-side).
+ * Intended for use by event handlers.
+ */
+export function renderCartInventory(
+  cart: Store["cartPrototype"],
+  tableId: string,
+  includeRemove: boolean
+) {
+  const tbodyEl = document.getElementById(tableId) as HTMLTableSectionElement;
+  if (!tbodyEl) throw new Error("table not found");
+  tbodyEl.innerHTML = "";
+
+  const entries = Object.entries(cart);
+  for (const [id, { quantity, unitPrice }] of entries) {
+    const rowEl = document.createElement("tr");
+    rowEl.innerHTML = `
+      <td>${startCase(id.replace(/-/g, " "))}</td>
+      <td>$${unitPrice.toFixed(2)}</td>
+      <td>${quantity}</td>
+    `;
+
+    if (includeRemove) {
+      const removeCell = document.createElement("td");
+      removeCell.innerHTML = `<button id="${id}-remove" type="button">Remove</button>`;
+      rowEl.appendChild(removeCell);
+    }
+
+    tbodyEl.appendChild(rowEl);
+  }
+}

--- a/site/src/lib/client/form.ts
+++ b/site/src/lib/client/form.ts
@@ -1,0 +1,15 @@
+/**
+ * Runs client-side validation against specified form inputs.
+ * Assumes all specified fields are text input elements,
+ * testing values against regular expressions and applying error styles.
+ */
+export function validateInputs(form: HTMLFormElement, validations: Record<string, RegExp>) {
+  let hasInvalidFields = false;
+  for (const [name, pattern] of Object.entries(validations)) {
+    const input = form.elements[name] as HTMLInputElement;
+    const isValid = pattern.test(input.value);
+    input.classList.toggle("error", !isValid);
+    if (!isValid) hasInvalidFields = true;
+  }
+  return hasInvalidFields;
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -11,6 +11,10 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       This site is designed to demonstrate a wide range of accessibility
       failures, for teaching and assessment purposes.
     </p>
+    <p>
+      <strong>Reminder:</strong> This site is an example and does not perform
+      real sign-in or payment processing. Do not enter real information!
+    </p>
   </section>
 
   <section id="summary-of-failures">
@@ -43,12 +47,108 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       </dl>
     </MetaFailureSection>
 
+    <MetaFailureSection href="museum/gift-shop/checkout/" title="Gift Shop Checkout">
+      <p>Note: One or more items must be in the cart to continue the checkout process.</p>
+      <dl slot="wcag2">
+        <dt>2.2.3: No Timing</dt>
+        <dd>
+          Forms in the checkout process time out after an undisclosed period of time.
+        </dd>
+        <dt>3.3.1: Error Identification</dt>
+        <dd>
+          Errors do not specifically describe what expectation was failed for each field.
+        </dd>
+        <dt>3.3.2: Labels or Instructions</dt>
+        <dd>
+          Fields have no labels, and no indication is given on accepted input formats.
+        </dd>
+        <dt>3.3.3: Error Suggestion</dt>
+        <dd>
+          Errors do not provide suggested corrections.
+        </dd>
+        <dt>3.3.4 and 3.3.6: Error Prevention</dt>
+        <dd>
+          There is no confirmation step after entering payment information,
+          failing 3.3.4 for financial information in addition to 3.3.6.
+        </dd>
+        <dt>3.3.5: Help</dt>
+        <dd>
+          No context-sensitive help is available.
+        </dd>
+      </dl>
+      <dl slot="wcag3">
+        <dt>Allow automated entry</dt>
+        <dd>
+          The input fields on the payment step disallow paste.
+        </dd>
+        <dt>Error association</dt>
+        <dd>
+          There is no error message programmatically associated with each input.
+        </dd>
+        <dt>Error identification</dt>
+        <dd>
+          The only indication of error is a border color change.
+        </dd>
+        <dt>Error notification</dt>
+        <dd>
+          Errors do not specifically describe what expectation was failed for each field.
+        </dd>
+        <dt>Input instructions</dt>
+        <dd>
+          No indication of input formats is provided.
+        </dd>
+        <dt>Input labels</dt>
+        <dd>
+          No input labels are present.
+        </dd>
+        <dt>Persistent error notification</dt>
+        <dd>
+          There is no way to dismiss errors until the entire form is resubmitted.
+        </dd>
+        <dt>Visible error</dt>
+        <dd>
+          There is only one generic error message, at the top of the entire form.
+        </dd>
+        <dt>Adequate time</dt>
+        <dd>
+          There is a timeout on each step that may be too short to enter required information.
+        </dd>
+        <dt>Action required</dt>
+        <dd>
+          There is no visible indication of fields being required, until the user attempts to submit.
+        </dd>
+        <dt>Go back in process</dt>
+        <dd>
+          There is no mechanism within the page for stepping back through the process,
+          or indicating position within the process.
+        </dd>
+        <dt>Inform at start</dt>
+        <dd>
+          Nothing is disclosed up-front about the information that will be required to complete checkout.
+        </dd>
+        <dt>Numbered steps</dt>
+        <dd>
+          Checkout steps are not numbered; progress through the process is not indicated at all.
+        </dd>
+        <dt>Contextual Help</dt>
+        <dd>
+          No contextual help is available.
+        </dd>
+      </dl>
+    </MetaFailureSection>
+
     <MetaFailureSection href="museum/login/" title="Sign In">
       <dl slot="wcag2">
         <dt>1.4.3: Contrast (Minimum)</dt>
         <dd>Placeholder text does not meet the minimum contrast ratio.</dd>
         <dt>3.3.2: Labels or Instructions</dt>
         <dd>Form inputs have no labels.</dd>
+      </dl>
+      <dl slot="wcag3">
+        <dt>Input labels</dt>
+        <dd>Form inputs have no labels.</dd>
+        <dt>Minimum text contrast</dt>
+        <dd>Placeholder text does not meet the minimum contrast ratio.</dd>
       </dl>
     </MetaFailureSection>
 

--- a/site/src/pages/museum/gift-shop/checkout/confirmation.astro
+++ b/site/src/pages/museum/gift-shop/checkout/confirmation.astro
@@ -1,0 +1,18 @@
+---
+import CartInventory from "@/components/cart/CartInventory.astro";
+import Layout from "@/layouts/Layout.astro";
+import { museumBaseUrl } from "@/lib/constants";
+---
+
+<Layout title="Order Confirmation">
+  <h1>Thank you for your order!</h1>
+  <h2 id="order">Order #</h2>
+  <CartInventory />
+  <p>
+    <a href={museumBaseUrl}>Return to Homepage</a>
+  </p>
+</Layout>
+
+<script>
+  document.getElementById("order")!.textContent = `Order #${Date.now()}`;
+</script>

--- a/site/src/pages/museum/gift-shop/checkout/index.astro
+++ b/site/src/pages/museum/gift-shop/checkout/index.astro
@@ -1,0 +1,21 @@
+---
+import CartInventory from "@/components/cart/CartInventory.astro";
+import CartStatus from "@/components/cart/CartStatus.astro";
+import Layout from "@/layouts/Layout.astro";
+---
+
+<Layout title="Checkout">
+  <h1>Checkout</h1>
+  <CartInventory includeRemove />
+  <CartStatus />
+  <a id="continue" class="button" href="shipping/" hidden>Continue</a>
+</Layout>
+
+<script>
+  import { onStoreChange } from "@/lib/client/store";
+
+  onStoreChange("cartPrototype", (cart) => {
+    document.getElementById("continue")!.hidden =
+      Object.keys(cart).length === 0;
+  });
+</script>

--- a/site/src/pages/museum/gift-shop/checkout/payment.astro
+++ b/site/src/pages/museum/gift-shop/checkout/payment.astro
@@ -1,0 +1,78 @@
+---
+import Fixable from "@/components/Fixable.astro";
+import Timeout from "@/components/Timeout.astro";
+import Layout from "@/layouts/Layout.astro";
+---
+
+<Layout title="Checkout">
+  <h1>Checkout</h1>
+  <h2>Payment Information</h2>
+  <p>
+    The payment method you enter below will be charged <strong id="total"
+    ></strong>.
+  </p>
+  <Fixable
+    as="form"
+    broken={{ action: "../confirmation/" }}
+    fixed={{ action: "../review/" }}
+  >
+    <p id="error" class="error" hidden></p>
+    <input name="name" placeholder="Name on Card" />
+    <input name="card" placeholder="Card Number" />
+    <input name="expiration" placeholder="Expiration" />
+    <input name="code" placeholder="CVC" />
+    <input name="zip" placeholder="ZIP Code" />
+    <button>Continue</button>
+    <Timeout>
+      The form has expired; please <a href="../">return to checkout</a> to start
+      over.
+    </Timeout>
+  </Fixable>
+</Layout>
+
+<script>
+  import { computeTotals } from "@/lib/client/cart";
+  import { validateInputs } from "@/lib/client/form";
+  import { recall } from "@/lib/client/store";
+  import { getMode } from "@/lib/mode";
+
+  const cart = recall("cartPrototype");
+  document.getElementById("total")!.textContent =
+    `$${computeTotals(cart).totalCost.toFixed(2)}`;
+
+  if (getMode() === "broken") {
+    document
+      .querySelectorAll("input")
+      .forEach((input) =>
+        input.addEventListener("paste", (event) => event.preventDefault())
+      );
+  }
+
+  document.querySelector("main form")?.addEventListener("submit", (event) => {
+    const hasInvalidFields = validateInputs(event.target as HTMLFormElement, {
+      name: /^.+$/,
+      card: /^\d{16}$/,
+      expiration: /^(0[1-9]|1[0-2])\/(2[4-9]|3\d)$/,
+      code: /^\d{3}$/,
+      zip: /^\d{5}$/,
+    });
+
+    if (hasInvalidFields) {
+      event.preventDefault();
+      const errorEl = document.getElementById("error") as HTMLParagraphElement;
+      errorEl.textContent = "Invalid payment information; please try again.";
+      errorEl.hidden = false;
+    }
+  });
+</script>
+
+<style>
+  form > * {
+    display: block;
+    margin: 1rem 0;
+  }
+
+  input::placeholder {
+    color: var(--gray-300);
+  }
+</style>

--- a/site/src/pages/museum/gift-shop/checkout/review.astro
+++ b/site/src/pages/museum/gift-shop/checkout/review.astro
@@ -1,0 +1,23 @@
+---
+import CartInventory from "@/components/cart/CartInventory.astro";
+import Layout from "@/layouts/Layout.astro";
+---
+
+<Layout title="Checkout">
+  <h1>Checkout</h1>
+  <h2>Review</h2>
+  <CartInventory />
+  <p><strong id="total"></strong> will be charged to the previously-entered card.</p>
+  <form action="../confirmation/">
+    <button>Place Order</button>
+  </form>
+</Layout>
+
+<script>
+  import { computeTotals } from "@/lib/client/cart";
+  import { recall } from "@/lib/client/store";
+
+  const cart = recall("cartPrototype");
+  document.getElementById("total")!.textContent =
+    `$${computeTotals(cart).totalCost}`;
+</script>

--- a/site/src/pages/museum/gift-shop/checkout/shipping.astro
+++ b/site/src/pages/museum/gift-shop/checkout/shipping.astro
@@ -1,0 +1,53 @@
+---
+import Timeout from "@/components/Timeout.astro";
+import Layout from "@/layouts/Layout.astro";
+---
+
+<Layout title="Checkout">
+  <h1>Checkout</h1>
+  <h2>Shipping Information</h2>
+  <form action="../payment/">
+    <p id="error" class="error" hidden></p>
+    <input name="street1" placeholder="Street Address" />
+    <input name="street2" placeholder="Apt. #" />
+    <input name="city" placeholder="City" />
+    <input name="state" placeholder="State" />
+    <input name="zip" placeholder="ZIP Code" />
+    <button>Continue</button>
+    <Timeout>
+      The form has expired; please <a href="../">return to checkout</a> to start
+      over.
+    </Timeout>
+  </form>
+</Layout>
+
+<script>
+  import { validateInputs } from "@/lib/client/form";
+
+  document.querySelector("main form")?.addEventListener("submit", (event) => {
+    const hasInvalidFields = validateInputs(event.target as HTMLFormElement, {
+      street1: /^.+$/,
+      city: /^.+$/,
+      state: /^[A-Z]{2}$/,
+      zip: /^\d{5}$/,
+    });
+
+    if (hasInvalidFields) {
+      event.preventDefault();
+      const errorEl = document.getElementById("error") as HTMLParagraphElement;
+      errorEl.textContent = "Invalid shipping information; please try again.";
+      errorEl.hidden = false;
+    }
+  });
+</script>
+
+<style>
+  form > * {
+    display: block;
+    margin: 1rem 0;
+  }
+
+  input::placeholder {
+    color: var(--gray-300);
+  }
+</style>

--- a/site/src/pages/museum/gift-shop/index.astro
+++ b/site/src/pages/museum/gift-shop/index.astro
@@ -1,6 +1,7 @@
 ---
+import CartStatus from "@/components/cart/CartStatus.astro";
 import Layout from "@/layouts/Layout.astro";
-import { startCase } from "lodash-es";
+import startCase from "lodash-es/startCase";
 
 // TODO: flesh out products, likely in a content collection;
 // this is temporary to test cart functionality
@@ -24,113 +25,41 @@ const products = {
 
 <Layout title="Gift Shop">
   <h1>Gift Shop</h1>
-  <div class="container">
-    <div class="products">
-      <h2>Products</h2>
-      {
-        Object.keys(products).map((category) => (
-          <>
-            <h3>{category}</h3>
-            <ul>
-              {Object.entries(products[category]).map(([id, unitPrice]) => (
-                <li>
-                  {startCase(id.replace(/-/g, " "))} (${unitPrice}){" "}
-                  <button id={`${id}-add`} data-price={unitPrice} type="button">
-                    Add to cart
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </>
-        ))
-      }
-    </div>
-    <div class="cart">
-      <h2>Cart</h2>
-      <p id="cart-empty">No items in cart.</p>
-      <ul id="cart-list"></ul>
-      <p id="cart-total" hidden></p>
-    </div>
+  <CartStatus />
+  <div>
+    <h2>Products</h2>
+    {
+      Object.keys(products).map((category) => (
+        <>
+          <h3>{category}</h3>
+          <ul>
+            {Object.entries(products[category]).map(([id, unitPrice]) => (
+              <li>
+                {startCase(id.replace(/-/g, " "))} (${unitPrice}){" "}
+                <button id={`${id}-add`} data-price={unitPrice} type="button">
+                  Add to cart
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
+      ))
+    }
   </div>
 </Layout>
 
 <script>
-  import startCase from "lodash-es/startCase";
-  import { persist, recall } from "@/lib/client/store";
+  import { handleCartInteractions } from "@/lib/client/cart";
 
-  const cart = recall("cartPrototype");
-  renderCart();
-
-  function renderCart() {
-    const listEl = document.getElementById("cart-list") as HTMLUListElement;
-    listEl.innerHTML = "";
-
-    const totalEl = document.getElementById(
-      "cart-total"
-    ) as HTMLParagraphElement;
-
-    const entries = Object.entries(cart);
-    document.getElementById("cart-empty")!.hidden = !!entries.length;
-    totalEl.hidden = !entries.length;
-
-    let total = 0;
-    for (const [id, { quantity, unitPrice }] of entries) {
-      const removeEl = document.createElement("button");
-      removeEl.id = `${id}-remove`;
-      removeEl.type = "button";
-      removeEl.textContent = "Remove";
-
-      const itemEl = document.createElement("li");
-      itemEl.textContent = `${startCase(id.replace(/-/g, " "))} (${quantity} × $${unitPrice}) `;
-      itemEl.appendChild(removeEl);
-
-      listEl.appendChild(itemEl);
-
-      total += quantity * unitPrice;
-    }
-
-    totalEl.innerHTML = `<strong>Total: $${total.toFixed(2)}</strong>`;
-  }
-
-  document.body.addEventListener("click", (event) => {
-    const buttonEl = event.target as HTMLButtonElement;
-    if (buttonEl.tagName !== "BUTTON") return;
-    const match = /^(.*)-(add|remove)$/.exec(buttonEl.id);
-    if (!match || !match[1]) return;
-
-    const cartProduct = cart[match[1]];
-    if (cartProduct) {
-      cartProduct.quantity += match[2] === "add" ? 1 : -1;
-      if (cartProduct.quantity < 1) delete cart[match[1]];
-    } else if (match[2] === "add") {
-      cart[match[1]] = { quantity: 1, unitPrice: +buttonEl.dataset.price! };
-    }
-
-    renderCart();
-    persist("cartPrototype", cart);
-  });
+  handleCartInteractions();
 </script>
 
 <style>
-  .container {
-    display: flex;
-    gap: calc(1rem * var(--ms15));
-  }
-
-  .products {
-    flex-grow: 1;
-  }
-
-  .cart {
-    width: 20rem;
-  }
-
   ul {
     list-style-type: none;
     padding: 0;
 
-    /* This needs to be nested to reach programmatically-generated list items */
-    li {
+    & li {
       display: flex;
       align-items: center;
       justify-content: space-between;

--- a/site/src/pages/museum/login/index.astro
+++ b/site/src/pages/museum/login/index.astro
@@ -8,7 +8,7 @@ import { museumBaseUrl } from "@/lib/constants";
 <Layout title="Sign In">
   <h1>Sign In</h1>
   {/* TODO: dedicated successful login page? */}
-  <form action={`${museumBaseUrl}`} method="post">
+  <form action={`${museumBaseUrl}`}>
     <FixableRegion>
       <input class="broken" name="username" placeholder="username" />
       <input

--- a/site/src/pages/museum/volunteer/index.astro
+++ b/site/src/pages/museum/volunteer/index.astro
@@ -1,5 +1,6 @@
 ---
 import Fixable from "@/components/Fixable.astro";
+import Timeout from "@/components/Timeout.astro";
 import Layout from "@/layouts/Layout.astro";
 ---
 
@@ -25,24 +26,12 @@ import Layout from "@/layouts/Layout.astro";
       >Phone number
       <Fixable as="input" fixed={{ type: "tel" }} name="phone" />
     </label>
-    <p id="timeout" class="error" hidden>
+    <Timeout>
       The form has expired; please refresh the page to start over.
-    </p>
+    </Timeout>
     <button type="submit">Submit</button>
   </form>
 </Layout>
-
-<script>
-  const form = document.querySelector("main form") as HTMLFormElement;
-  // Intentionally (and rudely) lock out the form after a time period
-  setTimeout(() => {
-    document.getElementById("timeout")!.hidden = false;
-    form.querySelectorAll("input").forEach((input) => (input.disabled = true));
-    form
-      .querySelectorAll("button")
-      .forEach((button) => (button.disabled = true));
-  }, 30000);
-</script>
 
 <style>
   form > * {

--- a/site/src/pages/museum/volunteer/index.astro
+++ b/site/src/pages/museum/volunteer/index.astro
@@ -4,7 +4,7 @@ import Layout from "@/layouts/Layout.astro";
 ---
 
 <Layout title="Volunteer">
-  <form action="thank-you/" method="post">
+  <form action="thank-you/">
     <label
       >First name
       <input name="firstname" />


### PR DESCRIPTION
This adds functionality for a multi-step checkout flow:

- Intentionally shows no indications of the full process or which step number the user is on
- All fields are intentionally unlabeled
- There is intentionally only a generic error above all fields; each invalid field is only marked using border color
- There is intentionally no up-front indication of required fields

Styles are currently minimal, pending input from designers.

An initial pass at updates to the meta homepage is included.

Additional changes:

- Refactored existing cart logic (from #14) into components/functions for reuse between shop and checkout
- Refactored timeout logic (originally from #10) into component for reuse between volunteer form and checkout steps
- Added `onStoreChange` API for DOM updates in reaction to store changes
- Changed all existing forms to GET, since POST won't work with either GitHub pages or local `npm run astro preview`
- Added default slot to `Fixable` to allow use for elements with children that vary only in attributes (e.g. the payment form going straight to order placed confirmation vs. review step)
- Added default slot to `MetaFailureSection` to allow adding general notes above WCAG-version-specific definition lists