### PR TITLE
Update Node docs, add check script, avoid checking dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,26 @@ If you don't have one, we recommend installing an IDE that supports multiple lan
 
 The next step is to determine which development environment you would like to use. You can choose between a couple of options:
 
-1) Running in a Docker container.
-2) A direct Node.js install.
+- A direct Node.js install.
+- Running in a Docker container.
 
-### Setting up a Development Environment using Docker.
+### Setting up a Development Environment using Node
+
+**Note:** `npm` commands should be run **within the `site` directory**.
+
+1. Install the [LTS version of Node](https://nodejs.org/en/download/prebuilt-installer/current) on your development machine.
+   - If you need to manage multiple Node versions, you can use
+     [fnm](https://github.com/Schniz/fnm) or [nvm](https://github.com/nvm-sh/nvm)
+1. Run `npm install` within the `site` directory to install the JS dependencies.
+1. Run `npm start` within the `site` directory to run the development server.
+
+Other useful npm commands within the `site` directory:
+
+- `npm run check` to check for TypeScript errors
+- `npm run build` to create a production build
+- `npm run preview` to preview the production build created by `npm run build`
+
+### Setting up a Development Environment using Docker
 
 1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop) or another way to run a containerized environment.
   * If on Windows, we recommend installing the [Linux Subsystem](https://learn.microsoft.com/en-us/windows/wsl/install) to help performance, but it’s not required. See [configuring Docker Desktop to use WSL 2](https://docs.docker.com/desktop/wsl/).
@@ -28,9 +44,3 @@ The next step is to determine which development environment you would like to us
   * If preferred, install some integration with the IDE you are using instead.
     * For instance, [`Makefile` support for VS Code](https://devblogs.microsoft.com/cppblog/now-announcing-makefile-support-in-visual-studio-code/)
 3. Run `make serve` to launch the container, install the dependencies and run the development server.
-
-### Setting up a Development Environment using Node.
-
-1. Install the [LTS version of Node](https://nodejs.org/en/download/prebuilt-installer/current) on your development machine.
-2. Run `npm install` from the `site` directory to install the JS dependencies.
-3. Run `npm run dev` from the `site` directory to run the development server.

--- a/site/package.json
+++ b/site/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "check": "astro check",
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -7,5 +7,6 @@
       "@/*": ["src/*"],
     },
     "strictNullChecks": true,
-  }
+  },
+  "exclude": ["dist"],
 }


### PR DESCRIPTION
Changes:

- Expands node docs, attempts to further emphasize `site` directory, and moves node above docker as it is likely easier for most users
- Adds `check` script
- Updates tsconfig so `check` won't flag built content under `dist`