### PR TITLE
Implement inaccessible search behavior

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,12 +13,14 @@
         "@fontsource/patua-one": "^5.0.19",
         "astro": "^4.13.3",
         "astro-icon": "^1.1.0",
+        "fast-glob": "^3.3.2",
         "lodash-es": "^4.17.21",
         "typescript": "^5.5.4"
       },
       "devDependencies": {
         "@iconify-json/ri": "^1.1.21",
         "@types/lodash-es": "^4.17.12",
+        "@types/node": "^20.14.14",
         "prettier": "3.3.2"
       }
     },
@@ -1859,9 +1861,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
-      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/site/package.json
+++ b/site/package.json
@@ -16,12 +16,14 @@
     "@fontsource/patua-one": "^5.0.19",
     "astro": "^4.13.3",
     "astro-icon": "^1.1.0",
+    "fast-glob": "^3.3.2",
     "lodash-es": "^4.17.21",
     "typescript": "^5.5.4"
   },
   "devDependencies": {
     "@iconify-json/ri": "^1.1.21",
     "@types/lodash-es": "^4.17.12",
+    "@types/node": "^20.14.14",
     "prettier": "3.3.2"
   }
 }

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,10 +1,10 @@
 ---
 import { Image } from "astro:assets";
-import { Icon } from "astro-icon/components";
 import { museumBaseUrl } from "@/lib/constants";
+import Search from "./Search.astro";
+import UserControls from "./UserControls.astro";
 
 import logo from "@/assets/images/mbt-logo.webp";
-import UserControls from "./UserControls.astro";
 ---
 
 <header>
@@ -19,12 +19,7 @@ import UserControls from "./UserControls.astro";
     <div>Museum of Broken Things</div>
   </div>
   <div>
-    <form role="search">
-      <input type="search" placeholder="Search" aria-label="Search" />
-      <button class="outline">
-        <Icon name="ri:search-line" />
-      </button>
-    </form>
+    <Search />
     <UserControls />
   </div>
 </header>
@@ -48,15 +43,6 @@ import UserControls from "./UserControls.astro";
     text-transform: uppercase;
     & img {
       display: block; /* avoids descender space under image */
-    }
-  }
-
-  form {
-    display: flex;
-    align-items: stretch;
-    button {
-      position: relative;
-      inset-inline-start: -1px;
     }
   }
 </style>

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -1,0 +1,96 @@
+---
+import { Icon } from "astro-icon/components";
+import FixableRegion from "./FixableRegion.astro";
+import { museumBaseUrl } from "@/lib/constants";
+---
+
+<FixableRegion>
+  <input id="search" placeholder="Search" />
+  <form slot="fixed" role="search" action={`${museumBaseUrl}search/`}>
+    <label
+      >Search
+      <input id="search" type="search" name="query" />
+    </label>
+    <button class="outline"><Icon name="ri:search-line" /></button>
+  </form>
+</FixableRegion>
+
+<script>
+  import debounce from "lodash-es/debounce";
+  import { museumBaseUrl } from "@/lib/constants";
+  import { getMode } from "@/lib/mode";
+  import type { SearchResult } from "@/pages/museum/api/search";
+
+  const allResults = (await (
+    await fetch(`${museumBaseUrl}api/search/`)
+  ).json()) as SearchResult[];
+
+  const searchInput = document.getElementById("search") as HTMLInputElement;
+
+  function search(query: string) {
+    searchInput.value = query;
+    const filteredResults = allResults.filter(({ title }) =>
+      title.toLowerCase().includes(query.toLowerCase())
+    );
+    const resultsHtml = query
+      ? `<ul>${filteredResults.map(
+          ({ title, url }) => `<li><a href="${url}">${title}</a></li>`
+        )}</ul>`
+      : "<p>No query specified.</p>";
+
+    const mainEl = document.querySelector("main") as HTMLElement;
+    mainEl.innerHTML = `
+      <h1>Search Results</h1>
+      ${resultsHtml}
+    `;
+  }
+
+  // Perform search immediately when loading this component on search page
+  const url = new URL(location.href);
+  if (url.pathname === `${museumBaseUrl}search/`) {
+    const query = url.searchParams.get("query") || "";
+    search(query);
+  }
+
+  if (getMode() === "broken") {
+    window.addEventListener("popstate", (event) => {
+      const url = new URL(location.href);
+      const query = url.searchParams.get("query") || "";
+      if (url.pathname === `${museumBaseUrl}search/`) search(query);
+      else location.reload(); // Perform full navigation when leaving search page
+    });
+
+    searchInput.addEventListener(
+      "input",
+      debounce(() => {
+        const query = searchInput.value;
+
+        if (location.pathname !== "/search")
+          history.replaceState({}, "", location.href);
+        // No-op if the value didn't change after debounced input events
+        else if (query === new URL(location.href).searchParams.get("query"))
+          return;
+
+        history.pushState(
+          {},
+          "",
+          `${museumBaseUrl}search/?query=${encodeURIComponent(query)}`
+        );
+
+        search(query);
+      }, 500)
+    );
+  }
+</script>
+
+<style>
+  form {
+    display: flex;
+    align-items: stretch;
+    button {
+      padding: 0 calc(1rem * var(--ms-6));
+      position: relative;
+      inset-inline-start: -1px;
+    }
+  }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -33,6 +33,23 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       )
     }
 
+    <MetaFailureSection href="museum/" title="Common Component: Search Box">
+      <dl slot="wcag2">
+        <dt>3.2.2: On Input</dt>
+        <dd>
+          The search box automatically performs client-side navigation to
+          the search page on a delay after input stops.
+          There is no dedicated submit button and no warning about the behavior.
+          (This may not be a failure for the search page itself.)
+          The page title also does not update to reflect the page change.
+        </dd>
+        <dt>4.1.2: Name, Role, Value</dt>
+        <dd>
+          There is no search landmark indicating the presence or purpose of the search box.
+        </dd>
+      </dl>
+    </MetaFailureSection>
+
     <MetaFailureSection href="museum/" title="Home">
       <dl slot="wcag2">
         <dt>1.4.3: Contrast (Minimum)</dt>

--- a/site/src/pages/museum/api/search.ts
+++ b/site/src/pages/museum/api/search.ts
@@ -1,0 +1,34 @@
+import type { APIRoute } from "astro";
+import glob from "fast-glob";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { museumBaseUrl } from "@/lib/constants";
+
+export interface SearchResult {
+  title: string;
+  url: string;
+}
+
+export const GET: APIRoute = async () => {
+  const cwd = join("src", "pages", "museum");
+  const pages = await glob("**/*.astro", { cwd });
+  const pageResults: SearchResult[] = [];
+
+  for (const filename of pages) {
+    if (/\[.+\]/.test(filename)) continue; // Skip dynamic routes
+    const relativePath = filename
+      .replace(/index\.astro$/, "")
+      .replace(/\.astro$/, "/");
+    if (/.+\/.+/.test(relativePath)) continue; // Skip nested routes
+
+    const content = await readFile(join(cwd, filename), "utf8");
+    const title = /<Layout[^>]* title="([^"]+)"/.exec(content)?.[1];
+    if (title)
+      pageResults.push({
+        title,
+        url: museumBaseUrl + relativePath,
+      });
+  }
+
+  return new Response(JSON.stringify(pageResults));
+};

--- a/site/src/pages/museum/map.astro
+++ b/site/src/pages/museum/map.astro
@@ -2,6 +2,6 @@
 import Layout from "@/layouts/Layout.astro";
 ---
 
-<Layout title="Musuem Map">
+<Layout title="Museum Map">
   <p>This is the map.</p>
 </Layout>

--- a/site/src/pages/museum/search.astro
+++ b/site/src/pages/museum/search.astro
@@ -1,0 +1,7 @@
+---
+import Layout from "@/layouts/Layout.astro";
+---
+
+<Layout title="Search">
+  {/* Content will be produced programmatically from Search component */}
+</Layout>


### PR DESCRIPTION
This implements client-side search behavior and hooks it up to the search input in a way that should fail multiple SCs (documented in the top-level index).

## Changes

- Populates a static endpoint with search result data which is fetched then filtered client-side (currently only includes top-level pages; could add collection data at a later point when we have more of it)
- Hooks up search behavior using a debounced input event handler, which then replaces the content of the page causing a change in context (and neglects to update page title)
- Removes surrounding form and search button (still present in fixed version)
- Creates a search page so that directly accessing the URLs created by the client-side logic will also work (which also ensures the corrected form works)
- Fixed a title typo I noticed while testing search results