### PR TITLE
Add Register page with CAPTCHA

### DIFF
--- a/site/src/components/UserControls.astro
+++ b/site/src/components/UserControls.astro
@@ -12,11 +12,11 @@ import { museumBaseUrl } from "@/lib/constants";
   const signOutButton = document.getElementById("sign-out") as HTMLButtonElement;
 
   signOutButton.addEventListener("click", () => {
-    persist("isLoggedIn", false);
+    persist("loggedInAt", null);
     location.href = location.href;
   });
 
-  if (recall("isLoggedIn")) {
+  if (recall("loggedInAt")) {
     signInButton.hidden = true;
     signOutButton.hidden = false;
   }

--- a/site/src/lib/client/form.ts
+++ b/site/src/lib/client/form.ts
@@ -1,15 +1,26 @@
+import type { ZodObject, ZodRawShape } from "astro/zod";
+
 /**
- * Runs client-side validation against specified form inputs.
- * Assumes all specified fields are text input elements,
- * testing values against regular expressions and applying error styles.
+ * Runs client-side validation against specified form inputs,
+ * automatically marking fields with invalid values.
+ * Assumes all specified fields are text input elements.
  */
-export function validateInputs(form: HTMLFormElement, validations: Record<string, RegExp>) {
-  let hasInvalidFields = false;
-  for (const [name, pattern] of Object.entries(validations)) {
-    const input = form.elements[name] as HTMLInputElement;
-    const isValid = pattern.test(input.value);
-    input.classList.toggle("error", !isValid);
-    if (!isValid) hasInvalidFields = true;
+export function validateInputs<T extends ZodRawShape>(
+  form: HTMLFormElement,
+  schema: ZodObject<T>
+) {
+  const entryMap: Record<string, string> = {};
+  const formData = new FormData(form);
+  for (const [name, value] of formData.entries()) {
+    entryMap[name] = value as string;
+    // Initially clear error states; fields with errors after validation will be re-flagged
+    (form.elements[name] as HTMLInputElement).classList.remove("error");
   }
-  return hasInvalidFields;
+
+  const result = schema.safeParse(entryMap);
+  if (!result.success) {
+    for (const { path } of result.error.issues)
+      (form.elements[path.join(".")] as HTMLInputElement).classList.add("error");
+  }
+  return result;
 }

--- a/site/src/lib/client/store.ts
+++ b/site/src/lib/client/store.ts
@@ -7,7 +7,7 @@ const storage = localStorage;
  * Schema for validating and populating defaults for local store.
  * Every property should include .default for upgrade-friendliness.
  */
-const storeSchema = z.object({
+export const storeSchema = z.object({
   // Note(ken): This is intentionally under a temporary name
   // so that any existing values will be cleared when we finalize it
   cartPrototype: z
@@ -19,7 +19,11 @@ const storeSchema = z.object({
       })
     )
     .default({}),
-  isLoggedIn: z.boolean().default(false),
+  loggedInAt: z.string().datetime().nullable().default(null),
+  registration: z.object({
+    email: z.string(),
+    password: z.string(),
+  }).nullable().default(null),
 });
 export type Store = z.infer<typeof storeSchema>;
 type StoreKey = keyof Store;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -137,6 +137,13 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       </dl>
     </MetaFailureSection>
 
+    <MetaFailureSection href="museum/register/" title="Register">
+      <dl slot="wcag2">
+        <dt>1.1.1: Non-text Content</dt>
+        <dd>A CAPTCHA is required and no alternative is provided.</dd>
+      </dl>
+    </MetaFailureSection>
+    
     <MetaFailureSection href="museum/login/" title="Sign In">
       <dl slot="wcag2">
         <dt>1.4.3: Contrast (Minimum)</dt>

--- a/site/src/pages/museum/gift-shop/checkout/payment.astro
+++ b/site/src/pages/museum/gift-shop/checkout/payment.astro
@@ -31,6 +31,7 @@ import Layout from "@/layouts/Layout.astro";
 </Layout>
 
 <script>
+  import { z } from "astro/zod";
   import { computeTotals } from "@/lib/client/cart";
   import { validateInputs } from "@/lib/client/form";
   import { recall } from "@/lib/client/store";
@@ -51,15 +52,18 @@ import Layout from "@/layouts/Layout.astro";
   }
 
   form.addEventListener("submit", (event) => {
-    const hasInvalidFields = validateInputs(event.target as HTMLFormElement, {
-      name: /^.+$/,
-      card: /^\d{16}$/,
-      expiration: /^(0[1-9]|1[0-2])\/(2[4-9]|3\d)$/,
-      code: /^\d{3}$/,
-      zip: /^\d{5}$/,
-    });
+    const result = validateInputs(
+      event.target as HTMLFormElement,
+      z.object({
+        name: z.string().min(1),
+        card: z.string().regex(/^\d{16}$/),
+        expiration: z.string().regex(/^(0[1-9]|1[0-2])\/(2[4-9]|3\d)$/),
+        code: z.string().regex(/^\d{3}$/),
+        zip: z.string().regex(/^\d{5}$/),
+      })
+    );
 
-    if (hasInvalidFields) {
+    if (!result.success) {
       event.preventDefault();
       const errorEl = document.getElementById("error") as HTMLParagraphElement;
       errorEl.textContent = "Invalid payment information; please try again.";

--- a/site/src/pages/museum/gift-shop/checkout/shipping.astro
+++ b/site/src/pages/museum/gift-shop/checkout/shipping.astro
@@ -22,17 +22,21 @@ import Layout from "@/layouts/Layout.astro";
 </Layout>
 
 <script>
+  import { z } from "astro/zod";
   import { validateInputs } from "@/lib/client/form";
 
   document.querySelector("main form")?.addEventListener("submit", (event) => {
-    const hasInvalidFields = validateInputs(event.target as HTMLFormElement, {
-      street1: /^.+$/,
-      city: /^.+$/,
-      state: /^[A-Z]{2}$/,
-      zip: /^\d{5}$/,
-    });
+    const result = validateInputs(
+      event.target as HTMLFormElement,
+      z.object({
+        street1: z.string().min(1),
+        city: z.string().min(1),
+        state: z.string().regex(/^[A-Z]{2}$/),
+        zip: z.string().regex(/^\d{5}$/),
+      })
+    );
 
-    if (hasInvalidFields) {
+    if (!result.success) {
       event.preventDefault();
       const errorEl = document.getElementById("error") as HTMLParagraphElement;
       errorEl.textContent = "Invalid shipping information; please try again.";

--- a/site/src/pages/museum/login/index.astro
+++ b/site/src/pages/museum/login/index.astro
@@ -7,10 +7,10 @@ import { museumBaseUrl } from "@/lib/constants";
 
 <Layout title="Sign In">
   <h1>Sign In</h1>
-  {/* TODO: dedicated successful login page? */}
+  <p id="registered" hidden>Registration successful. Please sign in below.</p>
   <form action={`${museumBaseUrl}`}>
     <FixableRegion>
-      <input class="broken" name="username" placeholder="username" />
+      <input class="broken" name="email" placeholder="email@domain.com" />
       <input
         class="broken"
         type="password"
@@ -19,8 +19,8 @@ import { museumBaseUrl } from "@/lib/constants";
       />
       <Fragment slot="fixed">
         <label
-          >Username
-          <input class="fixed" name="username" placeholder="name" />
+          >Email
+          <input class="fixed" type="email" name="email" placeholder="name" />
         </label>
         <label>
           Password
@@ -31,16 +31,26 @@ import { museumBaseUrl } from "@/lib/constants";
     <Fixable as="p" id="notification" hidden fixed={{ tabindex: -1 }} />
     <button>Submit</button>
   </form>
+  <p id="register">
+    Don't have an account?
+    <a href="../register/">Register</a>
+  </p>
 </Layout>
 
 <script>
-  import { persist } from "@/lib/client/store";
+  import { persist, recall } from "@/lib/client/store";
   import { getMode } from "@/lib/mode";
+
+  if (new URL(location.href).searchParams.get("email")) {
+    document.getElementById("registered")!.hidden = false;
+    document.getElementById("register")!.hidden = true;
+  }
 
   const form = document.querySelector("main form") as HTMLFormElement;
   const notificationEl = document.getElementById(
     "notification"
   ) as HTMLParagraphElement;
+  const registration = recall("registration");
 
   if (getMode() === "broken") {
     form
@@ -59,18 +69,22 @@ import { museumBaseUrl } from "@/lib/constants";
 
   form.addEventListener("submit", (event) => {
     // Mock login validation
-    const usernameInput = form.elements["username"] as HTMLInputElement;
+    const emailInput = form.elements["email"] as HTMLInputElement;
     const passwordInput = form.elements["password"] as HTMLInputElement;
-    if (usernameInput.value !== "test" || passwordInput.value !== "WCAG") {
+    if (
+      !registration ||
+      emailInput.value !== registration.email ||
+      passwordInput.value !== registration.password
+    ) {
       event.preventDefault();
       notificationEl.removeAttribute("hidden");
       notificationEl.className = "error";
       notificationEl.textContent =
-        "Incorrect username or password; please try again.";
+        "Incorrect email or password; please try again.";
 
       if (getMode() === "fixed") notificationEl.focus();
     } else {
-      persist("isLoggedIn", true);
+      persist("loggedInAt", new Date().toISOString());
     }
   });
 </script>

--- a/site/src/pages/museum/register.astro
+++ b/site/src/pages/museum/register.astro
@@ -1,0 +1,87 @@
+---
+import Layout from "@/layouts/Layout.astro";
+---
+
+<Layout title="Create Account">
+  <h1>Create Account</h1>
+  <form action="../login/">
+    <h2>Account Information</h2>
+    <label
+      >Display Name
+      <input name="displayName" />
+    </label>
+    <label
+      >Email Address
+      <input type="email" name="email" />
+    </label>
+    <label
+      >Password
+      <input name="password" type="password" />
+    </label>
+    <label
+      >Confirm password
+      <input name="password-confirm" type="password" />
+    </label>
+    <h2>Prove You're a Human</h2>
+    <canvas id="captcha" width="360" height="80"></canvas>
+    <label
+      >Enter the letters shown above:
+      <input name="captcha" />
+    </label>
+    <button>Submit</button>
+  </form>
+</Layout>
+
+<script>
+  import { z } from "astro/zod";
+  import random from "lodash-es/random";
+  import { validateInputs } from "@/lib/client/form";
+  import { persist, storeSchema } from "@/lib/client/store";
+
+  const canvas = document.getElementById("captcha") as HTMLCanvasElement;
+  const ctx = canvas.getContext("2d")!;
+  ctx.font = "36px serif";
+
+  const codeLetters: string[] = [];
+  for (let i = 0; i < 5; i++)
+    codeLetters.push(String.fromCodePoint(random(65, 90)));
+  codeLetters.forEach((letter, i) => {
+    const tx = 50 + i * 60;
+    const ty = 30;
+    ctx.save();
+    ctx.translate(tx, ty);
+    ctx.rotate((random(0, 360) * Math.PI) / 180);
+    ctx.fillText(letter, 0, 0, 40);
+    ctx.restore();
+  });
+
+  const form = document.querySelector("main form") as HTMLFormElement;
+  form.addEventListener("submit", (event) => {
+    const codeText = codeLetters.join("");
+    const registrationSchema = storeSchema.shape.registration
+      .removeDefault()
+      .unwrap();
+
+    const result = validateInputs(
+      form,
+      registrationSchema.extend({
+        "displayName": z.string().min(1),
+        "password-confirm": z
+          .string()
+          .refine((value) => value === form.elements["password"].value),
+        captcha: z.string().refine((value) => value.toUpperCase() === codeText),
+      })
+    );
+
+    if (!result.success) event.preventDefault();
+    // Re-parse to strip fields that shouldn't persist
+    else persist("registration", registrationSchema.parse(result.data));
+  });
+</script>
+
+<style>
+  form > * {
+    display: block;
+    margin: 1rem 0;
+  }
+</style>


### PR DESCRIPTION
This adds a Register page (accessed from and complementing the existing Sign In page) which includes a client-side-generated CAPTCHA with no alternative, failing SC 1.1.1.

Changes aside from the new page:

- Updated `validateInputs` to always rely on a Zod schema
- Added persistence of registration information, which is now used to validate the sign in form instead of static/hard-coded credentials
- Updated `isLoggedIn` to `loggedInAt`, to add future possibility of time-based session expiration