### PR TITLE
Disallow paste on login page

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -143,8 +143,12 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>Placeholder text does not meet the minimum contrast ratio.</dd>
         <dt>3.3.2: Labels or Instructions</dt>
         <dd>Form inputs have no labels.</dd>
+        <dt>3.3.8 and 3.3.9: Accessible Authentication</dt>
+        <dd>The input fields disallow paste.</dd>
       </dl>
       <dl slot="wcag3">
+        <dt>Allow automated entry</dt>
+        <dd>The input fields disallow paste.</dd>
         <dt>Input labels</dt>
         <dd>Form inputs have no labels.</dd>
         <dt>Minimum text contrast</dt>

--- a/site/src/pages/museum/gift-shop/checkout/payment.astro
+++ b/site/src/pages/museum/gift-shop/checkout/payment.astro
@@ -40,15 +40,17 @@ import Layout from "@/layouts/Layout.astro";
   document.getElementById("total")!.textContent =
     `$${computeTotals(cart).totalCost.toFixed(2)}`;
 
+  const form = document.querySelector("main form") as HTMLFormElement;
+
   if (getMode() === "broken") {
-    document
+    form
       .querySelectorAll("input")
       .forEach((input) =>
         input.addEventListener("paste", (event) => event.preventDefault())
       );
   }
 
-  document.querySelector("main form")?.addEventListener("submit", (event) => {
+  form.addEventListener("submit", (event) => {
     const hasInvalidFields = validateInputs(event.target as HTMLFormElement, {
       name: /^.+$/,
       card: /^\d{16}$/,

--- a/site/src/pages/museum/login/index.astro
+++ b/site/src/pages/museum/login/index.astro
@@ -42,6 +42,14 @@ import { museumBaseUrl } from "@/lib/constants";
     "notification"
   ) as HTMLParagraphElement;
 
+  if (getMode() === "broken") {
+    form
+      .querySelectorAll("input")
+      .forEach((input) =>
+        input.addEventListener("paste", (event) => event.preventDefault())
+      );
+  }
+
   form.addEventListener("focusout", (event) => {
     const el = event.target as HTMLElement;
     if (el.tagName === "INPUT") {


### PR DESCRIPTION
This disallows paste on the login page to fail accessible authentication criteria, and fixes the no-paste behavior on the payments page to only affect inputs within the main form (i.e. not the search input).