### PR TITLE
Add more form-related failures

### DIFF
--- a/site/src/assets/styles/form-elements.css
+++ b/site/src/assets/styles/form-elements.css
@@ -15,6 +15,6 @@ input:not([type="checkbox"]):not([type="file"]):not([type="image"]):not([type="r
   }
 }
 
-p.error {
+div.error, p.error {
   color: var(--red-warm-500);
 }

--- a/site/src/components/Fixable.astro
+++ b/site/src/components/Fixable.astro
@@ -1,26 +1,40 @@
 ---
 /** @fileoverview
- * Component that enables defining both broken and fixed state of an HTML element.
- * Attributes specific to broken or fixed state can be nested within the respective
- * property; attributes common to both states can be specified top-level as usual.
+ * Component that enables defining both broken and fixed state of an element or component.
+ * Props specific to broken or fixed state can be nested within the respective
+ * property; props common to both states can be specified top-level as usual.
  */
 
-import { getMode } from '@/lib/mode';
-import type { HTMLTag, Polymorphic } from 'astro/types';
+import type { ComponentProps, HTMLTag, Polymorphic } from "astro/types";
+import { getMode } from "@/lib/mode";
 
 const mode = getMode();
 
-type Props<Tag extends HTMLTag> = Polymorphic<{ as: Tag }> & {
-  /** Any attributes that should only be set on the broken version */
-  broken?: Partial<Omit<Polymorphic<{ as: Tag }>, "as">>;
-  /** Any attributes that should only be set on the fixed version */
-  fixed?: Partial<Omit<Polymorphic<{ as: Tag }>, "as">>;
-};
+// NOTE: Props _needs_ to be the first declared type for Astro to process correctly
 
+type Props<Tag extends HTMLTag | AstroComponent> = Tag extends HTMLTag
+  ? Polymorphic<{ as: Tag }> &
+      SpecialCaseProps<Partial<Omit<Polymorphic<{ as: Tag }>, "as">>>
+  : Tag extends AstroComponent
+    ? // This second ternary is required to pass type checking but the `never` will never occur
+      ComponentProps<Tag> &
+        SpecialCaseProps<Partial<ComponentProps<Tag>>> & {
+          as: Tag;
+        }
+    : never;
+
+type AstroComponent = (args: any) => any;
+
+type SpecialCaseProps<T> = {
+  /** Any attributes that should only be set on the broken version */
+  broken?: T;
+  /** Any attributes that should only be set on the fixed version */
+  fixed?: T;
+};
 
 const { as: Tag, broken, fixed, ...props } = Astro.props;
 ---
 
-<Tag {...props} {...(mode === "broken" ? broken : fixed)}>
+<Tag {...props} {...mode === "broken" ? broken : fixed}>
   <slot />
 </Tag>

--- a/site/src/components/FormLayout.astro
+++ b/site/src/components/FormLayout.astro
@@ -1,0 +1,26 @@
+---
+import type { HTMLAttributes } from "astro/types";
+
+/** @fileoverview Form shell with general layout styles */
+
+interface Props extends HTMLAttributes<"form"> {}
+---
+
+<form {...Astro.props}>
+  <slot />
+</form>
+
+<style is:global>
+  main form {
+    > * {
+      display: block;
+      margin: 1rem 0;
+    }
+
+    select,
+    textarea,
+    input:not([type="checkbox"]):not([type="radio"]) {
+      display: block;
+    }
+  }
+</style>

--- a/site/src/lib/client/store.ts
+++ b/site/src/lib/client/store.ts
@@ -21,8 +21,8 @@ export const storeSchema = z.object({
     .default({}),
   loggedInAt: z.string().datetime().nullable().default(null),
   registration: z.object({
-    email: z.string(),
-    password: z.string(),
+    email: z.string().email(),
+    password: z.string().min(1),
   }).nullable().default(null),
 });
 export type Store = z.infer<typeof storeSchema>;

--- a/site/src/pages/museum/gift-shop/checkout/payment.astro
+++ b/site/src/pages/museum/gift-shop/checkout/payment.astro
@@ -1,18 +1,20 @@
 ---
 import Fixable from "@/components/Fixable.astro";
+import FixableRegion from "@/components/FixableRegion.astro";
+import FormLayout from "@/components/FormLayout.astro";
 import Timeout from "@/components/Timeout.astro";
 import Layout from "@/layouts/Layout.astro";
 ---
 
 <Layout title="Checkout">
   <h1>Checkout</h1>
-  <h2>Payment Information</h2>
+  <FixableRegion><h2 slot="fixed">Payment Information</h2></FixableRegion>
   <p>
     The payment method you enter below will be charged <strong id="total"
     ></strong>.
   </p>
   <Fixable
-    as="form"
+    as={FormLayout}
     broken={{ action: "../confirmation/" }}
     fixed={{ action: "../review/" }}
   >
@@ -73,11 +75,6 @@ import Layout from "@/layouts/Layout.astro";
 </script>
 
 <style>
-  form > * {
-    display: block;
-    margin: 1rem 0;
-  }
-
   input::placeholder {
     color: var(--gray-300);
   }

--- a/site/src/pages/museum/gift-shop/checkout/shipping.astro
+++ b/site/src/pages/museum/gift-shop/checkout/shipping.astro
@@ -1,13 +1,16 @@
 ---
+import FixableRegion from "@/components/FixableRegion.astro";
+import FormLayout from "@/components/FormLayout.astro";
 import Timeout from "@/components/Timeout.astro";
 import Layout from "@/layouts/Layout.astro";
 ---
 
 <Layout title="Checkout">
   <h1>Checkout</h1>
-  <h2>Shipping Information</h2>
-  <form action="../payment/">
-    <p id="error" class="error" hidden></p>
+  <FixableRegion><h2 slot="fixed">Shipping Information</h2></FixableRegion>
+  <FormLayout action="../payment/">
+    <div id="error" class="error" role="alert" hidden></div>
+    <input name="name" placeholder="Recipient Name" />
     <input name="street1" placeholder="Street Address" />
     <input name="street2" placeholder="Apt. #" />
     <input name="city" placeholder="City" />
@@ -18,39 +21,49 @@ import Layout from "@/layouts/Layout.astro";
       The form has expired; please <a href="../">return to checkout</a> to start
       over.
     </Timeout>
-  </form>
+  </FormLayout>
 </Layout>
 
 <script>
   import { z } from "astro/zod";
   import { validateInputs } from "@/lib/client/form";
+  import { getMode } from "@/lib/mode";
 
-  document.querySelector("main form")?.addEventListener("submit", (event) => {
-    const result = validateInputs(
-      event.target as HTMLFormElement,
-      z.object({
-        street1: z.string().min(1),
-        city: z.string().min(1),
-        state: z.string().regex(/^[A-Z]{2}$/),
-        zip: z.string().regex(/^\d{5}$/),
-      })
-    );
-
-    if (!result.success) {
-      event.preventDefault();
-      const errorEl = document.getElementById("error") as HTMLParagraphElement;
-      errorEl.textContent = "Invalid shipping information; please try again.";
-      errorEl.hidden = false;
-    }
+  const form = document.querySelector("main form") as HTMLFormElement;
+  const schema = z.object({
+    name: z.string().min(1, "Name is required."),
+    street1: z.string().min(1, "Street address line 1 is required."),
+    city: z.string().min(1, "City is required."),
+    state: z.string().regex(/^[A-Z]{2}$/, "State is invalid."),
+    zip: z.string().regex(/^\d{5}$/, "ZIP Code is invalid."),
   });
+
+  function refreshErrors() {
+    const result = validateInputs(form, schema);
+    const errorEl = document.getElementById("error") as HTMLParagraphElement;
+    if (!result.success) {
+      errorEl.innerHTML = `
+        <p>Invalid shipping information; please try again.</p>
+        <ul>
+          ${result.error.issues.map(({ message }) => `<li>${message}</li>`).join("\n")}
+        </ul>
+      `;
+    }
+    errorEl.hidden = result.success;
+
+    return result;
+  }
+  if (getMode() === "broken") refreshErrors();
+
+  form.addEventListener("submit", (event) => {
+    const result = refreshErrors();
+    if (!result.success) event.preventDefault();
+  });
+
+  form.addEventListener("focusout", refreshErrors);
 </script>
 
 <style>
-  form > * {
-    display: block;
-    margin: 1rem 0;
-  }
-
   input::placeholder {
     color: var(--gray-300);
   }

--- a/site/src/pages/museum/login/index.astro
+++ b/site/src/pages/museum/login/index.astro
@@ -1,6 +1,7 @@
 ---
 import Fixable from "@/components/Fixable.astro";
 import FixableRegion from "@/components/FixableRegion.astro";
+import FormLayout from "@/components/FormLayout.astro";
 import Layout from "@/layouts/Layout.astro";
 import { museumBaseUrl } from "@/lib/constants";
 ---
@@ -8,7 +9,15 @@ import { museumBaseUrl } from "@/lib/constants";
 <Layout title="Sign In">
   <h1>Sign In</h1>
   <p id="registered" hidden>Registration successful. Please sign in below.</p>
-  <form action={`${museumBaseUrl}`}>
+  <FormLayout class="form" action={`${museumBaseUrl}`}>
+    <Fixable
+      as="p"
+      id="error"
+      class="error"
+      hidden
+      role="alert"
+      fixed={{ tabindex: -1 }}
+    />
     <FixableRegion>
       <input class="broken" name="email" placeholder="email@domain.com" />
       <input
@@ -28,9 +37,8 @@ import { museumBaseUrl } from "@/lib/constants";
         </label>
       </Fragment>
     </FixableRegion>
-    <Fixable as="p" id="notification" hidden fixed={{ tabindex: -1 }} />
     <button>Submit</button>
-  </form>
+  </FormLayout>
   <p id="register">
     Don't have an account?
     <a href="../register/">Register</a>
@@ -47,9 +55,7 @@ import { museumBaseUrl } from "@/lib/constants";
   }
 
   const form = document.querySelector("main form") as HTMLFormElement;
-  const notificationEl = document.getElementById(
-    "notification"
-  ) as HTMLParagraphElement;
+  const errorEl = document.getElementById("error") as HTMLParagraphElement;
   const registration = recall("registration");
 
   if (getMode() === "broken") {
@@ -59,13 +65,6 @@ import { museumBaseUrl } from "@/lib/constants";
         input.addEventListener("paste", (event) => event.preventDefault())
       );
   }
-
-  form.addEventListener("focusout", (event) => {
-    const el = event.target as HTMLElement;
-    if (el.tagName === "INPUT") {
-      el.classList.toggle("error", !(el as HTMLInputElement).value);
-    }
-  });
 
   form.addEventListener("submit", (event) => {
     // Mock login validation
@@ -77,12 +76,10 @@ import { museumBaseUrl } from "@/lib/constants";
       passwordInput.value !== registration.password
     ) {
       event.preventDefault();
-      notificationEl.removeAttribute("hidden");
-      notificationEl.className = "error";
-      notificationEl.textContent =
-        "Incorrect email or password; please try again.";
+      errorEl.removeAttribute("hidden");
+      errorEl.textContent = "Incorrect email or password; please try again.";
 
-      if (getMode() === "fixed") notificationEl.focus();
+      if (getMode() === "fixed") errorEl.focus();
     } else {
       persist("loggedInAt", new Date().toISOString());
     }
@@ -90,9 +87,12 @@ import { museumBaseUrl } from "@/lib/constants";
 </script>
 
 <style>
-  form > * {
-    display: block;
-    margin: 1rem 0;
+  .form {
+    margin: 10vh 0;
+  }
+
+  button {
+    margin-top: calc(1rem * var(--ms9));
   }
 
   input.broken::placeholder {

--- a/site/src/pages/museum/register.astro
+++ b/site/src/pages/museum/register.astro
@@ -1,11 +1,20 @@
 ---
+import Fixable from "@/components/Fixable.astro";
+import FormLayout from "@/components/FormLayout.astro";
 import Layout from "@/layouts/Layout.astro";
 ---
 
 <Layout title="Create Account">
   <h1>Create Account</h1>
-  <form action="../login/">
+  <FormLayout action="../login/">
     <h2>Account Information</h2>
+    <Fixable
+      as="p"
+      id="error"
+      class="error"
+      hidden
+      fixed={{ role: "alert", tabindex: -1 }}
+    />
     <label
       >Display Name
       <input name="displayName" />
@@ -29,7 +38,7 @@ import Layout from "@/layouts/Layout.astro";
       <input name="captcha" />
     </label>
     <button>Submit</button>
-  </form>
+  </FormLayout>
 </Layout>
 
 <script>
@@ -37,6 +46,7 @@ import Layout from "@/layouts/Layout.astro";
   import random from "lodash-es/random";
   import { validateInputs } from "@/lib/client/form";
   import { persist, storeSchema } from "@/lib/client/store";
+  import { getMode } from "@/lib/mode";
 
   const canvas = document.getElementById("captcha") as HTMLCanvasElement;
   const ctx = canvas.getContext("2d")!;
@@ -55,6 +65,7 @@ import Layout from "@/layouts/Layout.astro";
     ctx.restore();
   });
 
+  const errorEl = document.getElementById("error") as HTMLParagraphElement;
   const form = document.querySelector("main form") as HTMLFormElement;
   form.addEventListener("submit", (event) => {
     const codeText = codeLetters.join("");
@@ -65,23 +76,25 @@ import Layout from "@/layouts/Layout.astro";
     const result = validateInputs(
       form,
       registrationSchema.extend({
-        "displayName": z.string().min(1),
+        displayName: z.string().min(1),
         "password-confirm": z
           .string()
+          .min(1)
           .refine((value) => value === form.elements["password"].value),
         captcha: z.string().refine((value) => value.toUpperCase() === codeText),
       })
     );
 
-    if (!result.success) event.preventDefault();
+    if (!result.success) {
+      event.preventDefault();
+      errorEl.textContent =
+        "All fields are required and the password fields must match.";
+      errorEl.hidden = false;
+
+      if (getMode() === "fixed") errorEl.focus();
+    }
+
     // Re-parse to strip fields that shouldn't persist
     else persist("registration", registrationSchema.parse(result.data));
   });
 </script>
-
-<style>
-  form > * {
-    display: block;
-    margin: 1rem 0;
-  }
-</style>

--- a/site/src/pages/museum/volunteer/index.astro
+++ b/site/src/pages/museum/volunteer/index.astro
@@ -1,11 +1,12 @@
 ---
 import Fixable from "@/components/Fixable.astro";
+import FormLayout from "@/components/FormLayout.astro";
 import Timeout from "@/components/Timeout.astro";
 import Layout from "@/layouts/Layout.astro";
 ---
 
 <Layout title="Volunteer">
-  <form action="thank-you/">
+  <FormLayout action="thank-you/">
     <label
       >First name
       <input name="firstname" />
@@ -30,15 +31,5 @@ import Layout from "@/layouts/Layout.astro";
       The form has expired; please refresh the page to start over.
     </Timeout>
     <button type="submit">Submit</button>
-  </form>
+  </FormLayout>
 </Layout>
-
-<style>
-  form > * {
-    display: block;
-    margin: 1rem 0;
-  }
-  input {
-    display: block;
-  }
-</style>


### PR DESCRIPTION
## User-facing Changes

- Add validation to more fields e.g. email, non-empty password + confirmation
- Add name field to shipping form (for added repetition with payment form)
- Add per-field error revalidation to shipping form and run it initially in broken version for worst possible UX
  - Remove per-field revalidation from login form since it doesn't have nearly as noticeable effects there
- Login: move error notification above fields and add spacing to make zoomed scroll a more plausible issue
- Registration: add error notification above fields, similar to login but also omit ARIA role in broken version
- Remove subheadings from broken shipping/payment checkout steps to more blatantly fail criteria

## Refactors

- Add `FormLayout` component to centralize repeated form styles (they're still minimal but they're already used in enough places that it can be onerous to update instances)
- Update `Fixable` to be usable on both native elements and Astro components (necessitated by `FormLayout` since one form has a conditional attribute for broken vs. fixed)