### PR TITLE
Fix checkout-specific CartStatus error

### DIFF
--- a/site/src/components/cart/CartStatus.astro
+++ b/site/src/components/cart/CartStatus.astro
@@ -25,7 +25,8 @@ import { museumBaseUrl } from "@/lib/constants";
       `${totalItems} item${totalItems === 1 ? "" : "s"}`;
     document.getElementById("cart-total-cost")!.textContent =
       `$${totalCost.toFixed(2)}`;
-    document.getElementById("cart-proceed")!.hidden =
-      Object.keys(cart).length === 0;
+
+    const proceedEl = document.getElementById("cart-proceed");
+    if (proceedEl) proceedEl.hidden = Object.keys(cart).length === 0;
   });
 </script>


### PR DESCRIPTION
This fixes an error that was easy to overlook in dev mode but causes the Continue button not to render in checkout when the site is built for production.