### PR TITLE
Work around webhost path handling discrepancies; fix TS error

### DIFF
--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -17,13 +17,13 @@ import { museumBaseUrl } from "@/lib/constants";
 
 <script>
   import debounce from "lodash-es/debounce";
+  import type { SearchResult } from "@/pages/museum/api/search";
   import { museumBaseUrl } from "@/lib/constants";
   import { getMode } from "@/lib/mode";
-  import type { SearchResult } from "@/pages/museum/api/search";
+  import { fetchApi } from "@/lib/client/fetch";
 
-  const allResults = (await (
-    await fetch(`${museumBaseUrl}api/search/`)
-  ).json()) as SearchResult[];
+  const response = await fetchApi(`${museumBaseUrl}api/search/`);
+  const allResults = (await response.json()) as SearchResult[];
 
   const searchInput = document.getElementById("search") as HTMLInputElement;
 
@@ -53,7 +53,7 @@ import { museumBaseUrl } from "@/lib/constants";
   }
 
   if (getMode() === "broken") {
-    window.addEventListener("popstate", (event) => {
+    window.addEventListener("popstate", () => {
       const url = new URL(location.href);
       const query = url.searchParams.get("query") || "";
       if (url.pathname === `${museumBaseUrl}search/`) search(query);

--- a/site/src/lib/client/fetch.ts
+++ b/site/src/lib/client/fetch.ts
@@ -1,0 +1,28 @@
+type FetchInput = Parameters<typeof fetch>[0];
+
+async function fetchAndExpect2xx(input: FetchInput, init?: RequestInit) {
+  const response = await fetch(input, init);
+  if (!response.ok)
+    throw new Error(`fetch(${input}): unexpected ${response.status}`);
+  return response;
+}
+
+/**
+ * fetch helper to smooth over discrepancies between Astro and static web hosts
+ */
+export async function fetchApi(url: string) {
+  const urlWithSlash = url + (url.endsWith("/") ? "" : "/");
+  const urlWithoutSlash = urlWithSlash.slice(0, -1);
+
+  if (import.meta.env.DEV) return fetchAndExpect2xx(urlWithSlash);
+
+  // Double-fetch is a workaround for issue similar to this:
+  // https://github.com/withastro/astro/issues/11447#issuecomment-2242978626
+  // (trailing slash works locally both dev and built, but 404s on GH Pages)
+  try {
+    // Prioritize the variation that works when deployed
+    return await fetchAndExpect2xx(urlWithoutSlash);
+  } catch (error) {
+    return await fetchAndExpect2xx(urlWithSlash);
+  }
+}


### PR DESCRIPTION
This works around an issue with #18 that I wasn't able to see until it hit GitHub Pages.

When working locally, both in dev and preview, the code in that PR worked fine. On GitHub Pages, however, the request for `/fixable/museum/api/search/` fails. Without the trailing slash, it succeeds, but that in turn fails in local environments. Relocating `api/search.ts` to `api/search/index.ts` has no effect on the situation.

This PR works around this by performing a 2nd fallback request if necessary in production mode, leading with the URL that is expected to work on GitHub Pages. When running in dev mode, the URL with trailing slash is immediately requested, since that is known to work in local development. The only case that will result in a 404 + fallback request is local `npm run preview`.

Verified by running a test deploy on my fork.