### PR TITLE
Rework layout, incl. repurposed grid, and mobile breakpoints

### DIFF
--- a/site/src/assets/styles/content-layout.css
+++ b/site/src/assets/styles/content-layout.css
@@ -1,10 +1,19 @@
-.wrapper {
-  display: grid;
-  gap: 1em;
-  grid-template-columns: [page-start] minmax(1em, 1fr) [content-start] repeat(8, 133px) [content-end] minmax(1em, 1fr) [page-end];
+@media (min-width: 30em) {
+  .grid-wrapper {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: [content-start] repeat(6, minmax(0, 133px)) [content-end];
+  }
+}
+
+@media (min-width: 60em) {
+  .grid-wrapper {
+    grid-template-columns: [content-start] repeat(12, minmax(0, 133px)) [content-end];
+  }
 }
 
 main {
-  grid-column: 2 / 10;
+  max-width: 75rem;
+  margin: 0 auto;
   padding: 1rem;
 }

--- a/site/src/assets/styles/utilities.css
+++ b/site/src/assets/styles/utilities.css
@@ -1,21 +1,38 @@
+/* For use with .hidden / breakpoint classes */
+.block {
+  display: block;
+}
+
 .hidden,
 [hidden] {
-  display: none !important;
+  display: none;
+}
+
+/* Responsive breakpoint classes */
+@media (width < 30em) {
+  .hidden-below-md {
+    display: none;
+  }
+}
+@media (width < 60em) {
+  .hidden-below-lg {
+    display: none;
+  }
 }
 
 .visually-hidden {
-	border: 0;
-	clip: rect(0, 0, 0, 0);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute;
-	white-space: nowrap;
-	width: 1px;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 /* Specialization of .visually-hidden for skip navigation link */
 .skip-link:focus-visible {
-	all: revert;
+  all: revert;
 }

--- a/site/src/components/CollectionCard.astro
+++ b/site/src/components/CollectionCard.astro
@@ -2,7 +2,7 @@
 import type { LocalImageProps } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
 import { pick } from "lodash-es";
-import LaxImage from "./LaxImage.astro";
+import CoverImage from "./CoverImage.astro";
 
 const imagePropNames = ["height", "width", "sizes", "widths"] as const;
 
@@ -30,7 +30,7 @@ const { description, image, title } =
 <div class:list={["card", extraClasses]} {style}>
   <div class={image.vertical ? "vertical" : "horizontal"}>
     <div class="image-container">
-      <LaxImage
+      <CoverImage
         src={image.src}
         alt={image.alt || null}
         object-fit="cover"

--- a/site/src/components/CoverImage.astro
+++ b/site/src/components/CoverImage.astro
@@ -3,8 +3,10 @@ import { getImage, type LocalImageProps } from "astro:assets";
 import { omit } from "lodash-es";
 
 /** @fileoverview
- * Custom Image component designed for the following edge cases:
+ * Custom Image component designed for object-fit: cover use cases,
+ * with the following alterations from Astro's Image component:
  * - Allows omitting alt text for intentional WCAG failures
+ *   (must be explicitly specified as null)
  * - Does not force setting width/height attributes on img,
  *   to avoid unwanted interference with object-fit
  * - Still runs through Astro's image optimization function
@@ -23,19 +25,23 @@ const image = await getImage({
   ...(typeof width === "string" && { width: parseInt(width) }),
 });
 
-const attributes =
-  "object-fit" in Astro.props
-    ? {
-        // Only include width/height if they were originally specified
-        ...omit(image.attributes, "height", "width"),
-        height,
-        width,
-      }
-    : image.attributes;
+const attributes = {
+  // Only include width/height if they were originally specified
+  ...omit(image.attributes, "height", "width"),
+  height,
+  width,
+};
 ---
 
-<img
+<img class="cover"
   src={image.src}
   {...attributes}
   {...image.srcSet.values.length && { srcset: image.srcSet.attribute }}
 />
+
+<style>
+  .cover {
+    object-fit: cover;
+    object-position: 33% center;
+  }
+</style>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -5,23 +5,34 @@ import logo from "@/assets/images/mbt-logo.webp";
 import { slugifyPath } from "@/lib/meta";
 import { navLinks } from "@/lib/nav-links";
 
-const metaAnchor = slugifyPath(Astro.url.pathname.replace(import.meta.env.BASE_URL, ""));
+const metaAnchor = slugifyPath(
+  Astro.url.pathname.replace(import.meta.env.BASE_URL, "")
+);
 ---
 
 <footer>
   <div class="links">
-    {navLinks.map(({ name, href }) => <a {href}>{name}</a>)}
+    {
+      navLinks.map(({ name, href, footerClass }) => (
+        <a class:list={["block", footerClass]} {href}>
+          {name}
+        </a>
+      ))
+    }
   </div>
   <div class="about">
     <Image src={logo} alt="Museum of Broken Things" width="256" height="256" />
     <p class="attribution">
-      The Museum of Broken Things is brought to you by Accessible Community and W3C, with
-      help from <a href="https://unsplash.com/">Unsplash</a> and various AI chatbots.
+      The Museum of Broken Things is brought to you by Accessible Community and
+      W3C, with help from <a href="https://unsplash.com/">Unsplash</a> and various
+      AI chatbots.
     </p>
     <p>
-      <a href={`${import.meta.env.BASE_URL}#${metaAnchor}`}>What's wrong with this page?</a>
+      <a href={`${import.meta.env.BASE_URL}#${metaAnchor}`}
+        >What's wrong with this page?</a
+      >
     </p>
-  </div>  
+  </div>
 </footer>
 
 <style>
@@ -31,7 +42,8 @@ const metaAnchor = slugifyPath(Astro.url.pathname.replace(import.meta.env.BASE_U
     justify-content: space-between;
     padding: 1.5rem;
 
-    &, & a {
+    &,
+    & a {
       color: var(--gold-vivid-400);
       text-decoration: none;
     }
@@ -47,12 +59,11 @@ const metaAnchor = slugifyPath(Astro.url.pathname.replace(import.meta.env.BASE_U
   .attribution {
     font-size: 70%;
     min-width: 250px;
-    max-width: 250px;    
+    max-width: 250px;
   }
 
   .links a {
     border-bottom: 1px solid var(--gold-vivid-400);
-    display: block;
     padding: 0.5rem;
 
     &:last-child {

--- a/site/src/components/Navigation.astro
+++ b/site/src/components/Navigation.astro
@@ -5,8 +5,8 @@ import { navLinks } from "@/lib/nav-links";
 <nav aria-label="Site">
   <ul>
     {
-      navLinks.map(({ name, href }) => (
-        <li>
+      navLinks.map(({ name, href, headerClass }) => (
+        <li class={headerClass}>
           <a {href}>{name}</a>
         </li>
       ))
@@ -31,6 +31,7 @@ import { navLinks } from "@/lib/nav-links";
       display: block;
       padding: 0.5em;
       text-decoration: none;
+      white-space: nowrap;
       &:hover {
         color: var(--white);
       }

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -25,11 +25,9 @@ const { title } = Astro.props;
     <a class="visually-hidden skip-link" href="#main">Skip to the main content</a>
     <Header />
     <Navigation />
-		<div class="wrapper">
-			<main id="main">
-				<slot />
-			</main>
-		</div>
+    <main id="main">
+      <slot />
+    </main>
     <Footer />
   </body>
 </html>

--- a/site/src/lib/nav-links.ts
+++ b/site/src/lib/nav-links.ts
@@ -3,12 +3,12 @@ import { museumBaseUrl } from "./constants";
 export const navLinks = [
   { href: "collections/", name: "Collections" },
   { href: "tour/", name: "Take a Tour" },
-  { href: "news/", name: "In the News" },
-  { href: "gift-shop/", name: "Gift Shop" },
+  { href: "news/", name: "In the News", headerClass: "hidden-below-lg" },
+  { href: "gift-shop/", name: "Gift Shop", headerClass: "hidden-below-lg", footerClass: "hidden-below-lg" },
   { href: "map/", name: "Museum Map" },
   { href: "volunteer/", name: "Volunteer" },
   { href: "about/", name: "About" },
-].map(({href, name}) => ({
+].map(({href, ...rest}) => ({
   href: `${museumBaseUrl}${href}`,
-  name
+  ...rest
 }));

--- a/site/src/pages/museum/index.astro
+++ b/site/src/pages/museum/index.astro
@@ -35,7 +35,6 @@ const collections = [
           description={description}
           image={imageItem.data.image}
           height="200"
-          style="max-height: 60rem; max-width: 60rem;"
         >
           <a slot="footer" class="btn btn-primary w-100" href={`collections/${tag}/`}>
             Explore
@@ -53,7 +52,8 @@ const collections = [
   .cards {
     display: grid;
     column-gap: 3rem;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: repeat(3, minmax(15rem, 1fr));
+    overflow: auto;
   }
 
   .cards-footer {


### PR DESCRIPTION
This includes some cleanup and preparatory work on the way to laying out collection and gift shop listing pages.

- Remove `wrapper` element from layout because it was proving to be actively harmful and not useful
  - IIUC, subgrids only work if every intermediate level forwards it, which would need to include `main`, which would not be useful in the majority of pages
  - Currently we were only using this for the equivalent of auto left/right margins + max-width on `main` (which is what I've changed the `main` element to now do instead)
  - The grid was effectively requiring the page to always be extremely wide, causing horizontal scrolling on _all_ pages at anything below nearly-full-screen desktop. While we might want this to break in some places, we probably don't want it broken _everywhere_
- Repurposed `.wrapper` styles into `.grid-wrapper`, intended to be used specifically when a grid is warranted
  - Now set up as a 12-column grid with no "gutter columns", for maximum divisibility for use for content
  - Downscales to 6-column grid at 60em (960px by default)
  - Removes grid entirely at 30em (480px by default)
  - This is not used in this PR but I am already using it in WIP for what will be the next PR, for updated collection listing layout, and I plan to use it again for gift shop listing layout
- Added utility classes for hiding content below the 30em and 60em breakpoints (relies on [range syntax](https://caniuse.com/css-media-range-syntax) for simplicity)
- Updated `LaxImage` once again, renamed/repurposed to `CoverImage` to better support the use cases we're actually using it for
- Implemented distinct hidden navigation items in header and footer, using the `hidden` + breakpoint classes to hide below 60em
- Added `white-space: nowrap` to the navigation bar to make horizontal overflow on mobile more noticeable (especially after removing items)
- Added `overflow: auto` to the grid container for the 3 collections highlighted on the homepage, to force horizontal scrolling regardless of the layout fixes noted above