### PR TITLE
Fix hidden styles

### DIFF
--- a/site/src/assets/styles/utilities.css
+++ b/site/src/assets/styles/utilities.css
@@ -1,22 +1,17 @@
-/* For use with .hidden / breakpoint classes */
-.block {
-  display: block;
-}
-
 .hidden,
 [hidden] {
-  display: none;
+  display: none !important;
 }
 
 /* Responsive breakpoint classes */
 @media (width < 30em) {
   .hidden-below-md {
-    display: none;
+    display: none !important;
   }
 }
 @media (width < 60em) {
   .hidden-below-lg {
-    display: none;
+    display: none !important;
   }
 }
 

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -14,7 +14,7 @@ const metaAnchor = slugifyPath(
   <div class="links">
     {
       navLinks.map(({ name, href, footerClass }) => (
-        <a class:list={["block", footerClass]} {href}>
+        <a class={footerClass} {href}>
           {name}
         </a>
       ))
@@ -64,6 +64,7 @@ const metaAnchor = slugifyPath(
 
   .links a {
     border-bottom: 1px solid var(--gold-vivid-400);
+    display: block;
     padding: 0.5rem;
 
     &:last-child {


### PR DESCRIPTION
This fixes a regression I didn't realize I caused while I was iterating on responsive styles, noticeable if you go to gift shop checkout with 0 items in cart (the continue button shouldn't be visible).

I had originally gone in the direction of adding responsive classes to "undo" display: none at breakpoints which is why I removed the `!important` and added the `block` class, but I ultimately ended up doing the opposite direction with the use of media range queries, so I can reinstate these. I still find it unfortunate to need to use `!important`, but it's somewhat necessary given unpredictable order of component styles.