### PR TITLE
Mark Home collection as dangerous; add "lightning" effect to its list

### DIFF
--- a/site/src/components/Modal.astro
+++ b/site/src/components/Modal.astro
@@ -5,20 +5,19 @@
  * native can use a submit button, relying on form method="dialog".
  */
 
-import { getMode } from "@/lib/mode";
+import { getMode, type Mode } from "@/lib/mode";
 
 interface Props {
-  class?: string;
   /** Whether to close upon clicking the backdrop (affects both modes) */
   closeOnBackdrop?: boolean;
   /** Whether to close upon pressing escape (affects broken mode only) */
   closeOnKeyboard?: boolean;
   id: string;
+  /** Allows forcing mode, intended for cases where the fixed version is always desired */
+  mode?: Mode;
 }
 
-const { class: extraClass, closeOnBackdrop, closeOnKeyboard, id } = Astro.props;
-const contentClassList = ["content", extraClass];
-const mode = getMode();
+const { closeOnBackdrop, closeOnKeyboard, id, mode = getMode() } = Astro.props;
 ---
 
 {
@@ -30,14 +29,14 @@ const mode = getMode();
       data-modal-close-on-backdrop={closeOnBackdrop}
       data-modal-close-on-keyboard={closeOnKeyboard}
     >
-      <div class:list={contentClassList}>
+      <div class="content">
         <slot />
       </div>
     </div>
   ) : (
     <dialog
       id={id}
-      class:list={contentClassList}
+      class="content"
       data-modal-close-on-backdrop={closeOnBackdrop}
     >
       <form method="dialog">

--- a/site/src/content/config.ts
+++ b/site/src/content/config.ts
@@ -33,6 +33,7 @@ export const collections = {
   "exhibit-categories": defineCollection({
     type: "content",
     schema: z.object({
+      dangerous: z.boolean().default(false),
       topDescription: z.string().optional(),
       topImageItem: reference("exhibits").optional(),
       title: z.string().min(1),

--- a/site/src/content/exhibit-categories/dishes.md
+++ b/site/src/content/exhibit-categories/dishes.md
@@ -1,7 +1,5 @@
 ---
 title: Dishes
-topDescription: Did someone say dinner?
-topImageItem: dishes/blue-dish
 ---
 
 Lorem markdownum toris quoque tardos auxiliumque illa, pariterque o mortis. Obit

--- a/site/src/content/exhibit-categories/home.md
+++ b/site/src/content/exhibit-categories/home.md
@@ -1,5 +1,8 @@
 ---
 title: Home
+dangerous: true
+topDescription: You rang?
+topImageItem: home/wide-bedroom
 ---
 
 Lorem markdownum retro risisse mixtam nigro precibus Aeaciden, sub albis legit

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -73,6 +73,16 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       </dl>
     </MetaFailureSection>
 
+    <MetaFailureSection href="museum/collections/home/" title="Home Collection">
+      <p><strong>Photosensitivity Warning!</strong> Do not visit this section if you experience reactions to flashing lights.</p>
+      <dl slot="wcag2">
+        <dt>2.3.2: Three Flashes</dt>
+        <dd>
+          The image thumbnails in the exhibit list on this page flash 4 times within a one-second period.
+        </dd>
+      </dl>
+    </MetaFailureSection>
+
     <MetaFailureSection href="museum/collections/technology/" title="Technology Collection">
       <dl slot="wcag2">
         <dt>1.1.1: Non-text Content</dt>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -76,7 +76,7 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
     <MetaFailureSection href="museum/collections/home/" title="Home Collection">
       <p><strong>Photosensitivity Warning!</strong> Do not visit this section if you experience reactions to flashing lights.</p>
       <dl slot="wcag2">
-        <dt>2.3.2: Three Flashes</dt>
+        <dt>2.3.1 and 2.3.2: Three Flashes</dt>
         <dd>
           The image thumbnails in the exhibit list on this page flash 4 times within a one-second period.
         </dd>

--- a/site/src/pages/museum/collections/[category]/index.astro
+++ b/site/src/pages/museum/collections/[category]/index.astro
@@ -2,7 +2,9 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 import { sortBy } from "lodash-es";
 import CoverImage from "@/components/CoverImage.astro";
+import Modal from "@/components/Modal.astro";
 import Layout from "@/layouts/Layout.astro";
+import { museumBaseUrl } from "@/lib/constants";
 
 interface Props {
   category: CollectionEntry<"exhibit-categories">;
@@ -34,25 +36,37 @@ const { Content } = await category.render();
   <Content />
   {
     category.data.dangerous && (
-      <div class="dangerous-warning">
-        <p>
-          <strong>Warning!</strong>
-        </p>
-        <p>
-          This category includes content that may be dangerous or unpleasant to
-          visitors who are sensitive to flashes or motion. Please do not
-          continue down this page or follow links below this point if you are
-          sensitive to flashes or motion.
-        </p>
-      </div>
+      <Modal id="warning-modal" mode="fixed">
+        <div class="warning-content">
+          <h2>Warning!</h2>
+          <p>
+            This category page demonstrates content that fails 2.3.1 and 2.3.2
+            (related to flashes), and pages for its individual items demonstrate
+            failures of 2.3.3 (related to animation). visitors who are sensitive
+            to flashes or motion are advised to
+            <a href={museumBaseUrl}>return to the homepage</a> and navigate
+            elsewhere.
+          </p>
+          <p>
+            If you are sure you would like to proceed, select a failure option
+            below.
+          </p>
+          <div class="warning-buttons">
+            <button name="submit" value="none">
+              No failures
+            </button>
+            <button name="submit" value="AAA">
+              Level AAA failure
+            </button>
+            <button name="submit" value="A">
+              Level A failure
+            </button>
+          </div>
+        </div>
+      </Modal>
     )
   }
-  <ul
-    class:list={[
-      "grid-wrapper",
-      ...(category.data.dangerous ? ["dangerous-list"] : []),
-    ]}
-  >
+  <ul class="grid-wrapper" id="list">
     {
       exhibits.map(({ data, slug }) => (
         <li>
@@ -74,12 +88,51 @@ const { Content } = await category.render();
   </ul>
 </Layout>
 
+<script>
+  import { showModal } from "@/lib/client/modal";
+
+  const modalId = "warning-modal";
+  const modalEl = document.getElementById(modalId);
+  if (modalEl) {
+    showModal(modalId);
+    const form = modalEl.querySelector("form") as HTMLFormElement;
+    form.addEventListener("submit", (event) => {
+      const value = (event.submitter as HTMLButtonElement).value;
+      const listEl = document.getElementById("list") as HTMLUListElement;
+      if (value.startsWith("A"))
+        listEl.classList.add("dangerous-list");
+      if (value === "A") listEl.classList.add("dangerous-list-A");
+      if (value === "none") listEl.classList.add("fading-list")
+    });
+  }
+</script>
+
 <style>
+  @keyframes fade {
+    0%,
+    100% {
+      opacity: 0.6;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+
   @keyframes lightning {
-    0%, 12%, 30%, 50% {
+    0%,
+    12%,
+    30%,
+    50% {
       opacity: 0.5;
     }
-    10%, 11%, 22%, 29%, 40%, 49%, 60%, 99% {
+    10%,
+    11%,
+    22%,
+    29%,
+    40%,
+    49%,
+    60%,
+    99% {
       opacity: 1;
     }
   }
@@ -96,10 +149,6 @@ const { Content } = await category.render();
     grid-column-end: span 2;
   }
 
-  .dangerous-list img {
-    animation: linear 2s infinite lightning;
-  }
-
   .image-container {
     height: calc(1rem * var(--ms20));
     overflow: hidden;
@@ -109,16 +158,37 @@ const { Content } = await category.render();
     }
   }
 
+  .dangerous-list img {
+    animation: linear 2s infinite lightning;
+  }
+
+  .dangerous-list-A .image-container {
+    background-color: red;
+  }
+
+  .fading-list img {
+    animation: linear 3s infinite fade;
+  }
+
   .content a {
     display: block;
     padding: 1rem;
     text-align: center;
   }
 
-  .dangerous-warning {
-    background-color: var(--gold-vivid-050);
+  .warning-content {
     font-size: calc(1rem * var(--ms2));
-    margin: calc(1rem * var(--ms10)) 0;
-    padding: calc(1rem * var(--ms20));
+    max-width: 60ch;
+    padding: 1rem;
+
+    & h2 {
+      text-align: center;
+    }
+  }
+
+  .warning-buttons {
+    display: flex;
+    gap: calc(1rem * var(--ms8));
+    justify-content: center;
   }
 </style>

--- a/site/src/pages/museum/collections/[category]/index.astro
+++ b/site/src/pages/museum/collections/[category]/index.astro
@@ -32,7 +32,27 @@ const { Content } = await category.render();
 <Layout title={category.data.title}>
   <h2>{category.data.title}</h2>
   <Content />
-  <ul class="grid-wrapper">
+  {
+    category.data.dangerous && (
+      <div class="dangerous-warning">
+        <p>
+          <strong>Warning!</strong>
+        </p>
+        <p>
+          This category includes content that may be dangerous or unpleasant to
+          visitors who are sensitive to flashes or motion. Please do not
+          continue down this page or follow links below this point if you are
+          sensitive to flashes or motion.
+        </p>
+      </div>
+    )
+  }
+  <ul
+    class:list={[
+      "grid-wrapper",
+      ...(category.data.dangerous ? ["dangerous-list"] : []),
+    ]}
+  >
     {
       exhibits.map(({ data, slug }) => (
         <li>
@@ -55,6 +75,15 @@ const { Content } = await category.render();
 </Layout>
 
 <style>
+  @keyframes lightning {
+    0%, 12%, 30%, 50% {
+      opacity: 0.5;
+    }
+    10%, 11%, 22%, 29%, 40%, 49%, 60%, 99% {
+      opacity: 1;
+    }
+  }
+
   ul {
     list-style: none;
     margin: 0;
@@ -65,6 +94,10 @@ const { Content } = await category.render();
     background: var(--white);
     border: 1px solid var(--hairline);
     grid-column-end: span 2;
+  }
+
+  .dangerous-list img {
+    animation: linear 2s infinite lightning;
   }
 
   .image-container {
@@ -80,5 +113,12 @@ const { Content } = await category.render();
     display: block;
     padding: 1rem;
     text-align: center;
+  }
+
+  .dangerous-warning {
+    background-color: var(--gold-vivid-050);
+    font-size: calc(1rem * var(--ms2));
+    margin: calc(1rem * var(--ms10)) 0;
+    padding: calc(1rem * var(--ms20));
   }
 </style>

--- a/site/src/pages/museum/collections/index.astro
+++ b/site/src/pages/museum/collections/index.astro
@@ -4,7 +4,7 @@ import Layout from "@/layouts/Layout.astro";
 import { sortBy } from "lodash-es";
 
 const categories = sortBy(
-  await getCollection("exhibit-categories"),
+  (await getCollection("exhibit-categories")).filter(({ data }) => !data.dangerous),
   ({ data }) => data.title
 );
 ---


### PR DESCRIPTION
- Add support for marking a collection as "dangerous":
  - Hides it from the overall Collection list page
  - Shows a warning modal on that collection's own list page; no flashing occurs until a choice is made in the modal
    - The failure choices add a "lightning" effect to the exhibits on the collection's list page (AAA uses white, A uses red)
    - The "no failures" choice applies a gradual fade instead
- Add `dangerous: true` to Home collection, removing it from the overall Collections list page
- Add `top*` properties to Home collection and remove from Dishes collection, adding it to the Home page, which is the only place it will be linked from

Modal component updates:

- Adds `mode` optional property, to allow forcing fixed mode even when the site is in broken mode
- Removes `class` property, which was unused and didn't fully work due to Astro's default style scope strategy behavior