### PR TITLE
Populate tour page with overly-frequent alerts and inconsistent nav

### DIFF
--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -3,22 +3,24 @@
 
 import "@/assets/styles/styles.css";
 
+import type { ComponentProps } from "astro/types";
 import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
 import Navigation from "@/components/Navigation.astro";
-import type { ComponentProps } from "astro/types";
 import BaseLayout from "./BaseLayout.astro";
+import { defaultNavLinks } from "@/lib/nav-links";
 
 type Props = ComponentProps<typeof BaseLayout> & {
+  headerNavLinks?: ComponentProps<typeof Navigation>["navLinks"];
   withInsetMain?: boolean;
 };
 
-const { title, withInsetMain = true } = Astro.props;
+const { headerNavLinks = defaultNavLinks, title, withInsetMain = true } = Astro.props;
 ---
 
 <BaseLayout title={title}>
   <Header />
-  <Navigation />
+  <Navigation navLinks={headerNavLinks} />
   <main id="main" class={withInsetMain ? "inset" : undefined}>
     <slot />
   </main>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -82,6 +82,19 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       </dl>
     </MetaFailureSection>
 
+    <MetaFailureSection href="museum/tour/" title="Take a Tour">
+      <dl slot="wcag2">
+        <dt>2.2.4: Interruptions</dt>
+        <dd>
+          The time to next departure is called out every 15 seconds and cannot be turned off.
+        </dd>
+        <dt>3.2.3: Consistent Navigation</dt>
+        <dd>
+          The "Take a Tour" item is missing from the top nav on this page.
+        </dd>
+      </dl>
+    </MetaFailureSection>
+
     <MetaFailureSection href="museum/blog/" title="Blog">
       <dl slot="wcag2">
         <dt>1.4.3 and 1.4.6: Contrast</dt>

--- a/site/src/pages/museum/tour.astro
+++ b/site/src/pages/museum/tour.astro
@@ -1,7 +1,84 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+import { getMode } from "@/lib/mode";
+import { defaultNavLinks } from "@/lib/nav-links";
+
+const headerNavLinks =
+  getMode() === "broken"
+    ? defaultNavLinks.filter(({ name }) => name !== "Take a Tour")
+    : defaultNavLinks;
 ---
 
-<Layout title="Take a Tour">
-  <p>This is the tour page.</p>
+<Layout title="Take a Tour" {headerNavLinks}>
+  <h1>Take a Tour</h1>
+  <div role="alert" class="next-tour">
+    Next tour departs in
+    <strong id="next-tour-countdown"></strong>
+  </div>
+
+  <p>
+    Lorem ipsum semperque pondera imagine Iolciacos gradibus nulli: ramosam est
+    oscula notamque, rutilis turba eadem animus, tibi. Nec et undarum habet
+    meritorum iubar.
+  </p>
+
+  <ol>
+    <li>Ipse illi animum Helicon</li>
+    <li>Quoniam rediit</li>
+    <li>Ille enim</li>
+    <li>Illa mihi promittit gerenti coeunt tibi isse</li>
+    <li>Adnuerat cruor tandem</li>
+    <li>Sacra an erant</li>
+  </ol>
+
+  <p>
+    Dedisse atria solis hebes, vulneris! Horrescere honores contingere rapta
+    recolligis cornu patrem aera, conscia at illic: Scylla studiosius: cum, hic
+    illo. Sacrificos urbem, lavere aris replet terrena dederat mortalis
+    mitissima eandem. Byblis carpit laetusque. Macareus cadensve, poples
+    intravere natum huic ramos?
+  </p>
+
+  <a class="button" href="take/">Take an upcoming tour</a>
 </Layout>
+
+<script>
+  import { getMode } from "@/lib/mode";
+
+  function updateNextTour() {
+    const now = Date.now();
+    const minutes = 60 - (Math.floor(now / 60000) % 60);
+    const seconds = 60 - (Math.floor(now / 1000) % 60);
+
+    const countdownEl = document.getElementById("next-tour-countdown")!;
+    if (getMode() === "broken")
+      countdownEl.textContent = `${minutes} minutes, ${seconds} seconds`;
+    else
+      countdownEl.textContent = minutes
+        ? `${minutes} minutes`
+        : "a few seconds";
+  }
+
+  updateNextTour();
+  setInterval(updateNextTour, getMode() === "broken" ? 15000 : 300000);
+</script>
+
+<style>
+  .next-tour {
+    background: var(--gold-vivid-050);
+    font-size: calc(1rem * var(--ms4));
+    padding: 1em;
+    text-align: center;
+
+    strong {
+      display: block;
+    }
+  }
+
+  @media (min-width: 30em) {
+    .next-tour {
+      float: right;
+      width: 14em;
+    }
+  }
+</style>


### PR DESCRIPTION
- Filled out tour page with role=alert element that updates every 15 seconds
- Added support for overriding nav bar links within the main Layout; set to skip "Take a Tour" on the tour page itself
- Take an upcoming tour link 404s (will see overly-vague error page once #31 is merged)