### PR TITLE
Add Carousel component to museum home page

### DIFF
--- a/site/src/assets/styles/content-layout.css
+++ b/site/src/assets/styles/content-layout.css
@@ -21,3 +21,9 @@ main.inset {
   margin: 0 auto;
   padding: 1rem;
 }
+
+/* Can be used to break out of .inset */
+.outset {
+  display: block;
+  margin: 0 calc((100% - 100vw) / 2);
+}

--- a/site/src/components/Carousel.astro
+++ b/site/src/components/Carousel.astro
@@ -1,8 +1,8 @@
 ---
+import type { CollectionEntry } from "astro:content";
 import { museumBaseUrl } from "@/lib/constants";
 import { getMode } from "@/lib/mode";
-import type { CollectionKey } from "astro:content";
-import type { CollectionEntry } from "astro:content";
+import FixableRegion from "./FixableRegion.astro";
 
 interface Props {
   entries: ImageEntry[];
@@ -15,7 +15,7 @@ type ImageEntry =
 
 const { entries } = Astro.props;
 
-const collectionLabels: Partial<Record<CollectionKey, string>> = {
+const collectionLabels = {
   blog: "Post",
   exhibits: "Exhibit",
   products: "Merch",
@@ -31,7 +31,12 @@ const collectionLabels: Partial<Record<CollectionKey, string>> = {
         {...(i && getMode() === "fixed" && { inert: true })}
       >
         <div class="scrim" />
-        <div class="overline">Latest {collectionLabels[entry.collection]}</div>
+        <FixableRegion>
+          <div class="overline">L A T E S T &nbsp; {
+            collectionLabels[entry.collection].toUpperCase().split("").join(" ")
+          }</div>
+          <div slot="fixed" class="overline">Latest {collectionLabels[entry.collection]}</div>
+        </FixableRegion>
         <div class="title">{entry.data.title}</div>
         <a
           class="button"
@@ -105,8 +110,6 @@ const collectionLabels: Partial<Record<CollectionKey, string>> = {
 
   .overline {
     font-size: calc(1rem * var(--ms3));
-    letter-spacing: calc(1rem * var(--ms4));
-    text-transform: uppercase;
   }
 
   .title {
@@ -186,6 +189,11 @@ const collectionLabels: Partial<Record<CollectionKey, string>> = {
 
     .scrim {
       z-index: -1;
+    }
+
+    .overline {
+      letter-spacing: calc(1rem * var(--ms4));
+      text-transform: uppercase;
     }
   }
 </style>

--- a/site/src/components/Carousel.astro
+++ b/site/src/components/Carousel.astro
@@ -30,7 +30,6 @@ const collectionLabels = {
         style={{ backgroundImage: `url(${entry.data.image.src})` }}
         {...(i && getMode() === "fixed" && { inert: true })}
       >
-        <div class="scrim" />
         <FixableRegion>
           <div class="overline">L A T E S T &nbsp; {
             collectionLabels[entry.collection].toUpperCase().split("").join(" ")
@@ -100,12 +99,13 @@ const collectionLabels = {
     &.out {
       z-index: 1;
     }
-  }
 
-  .scrim {
-    background-color: rgba(0, 0, 0, 0.4);
-    position: absolute;
-    inset: 0;
+    &::before {
+      background-color: rgba(0, 0, 0, 0.4);
+      content: "";
+      position: absolute;
+      inset: 0;
+    }
   }
 
   .overline {
@@ -133,15 +133,15 @@ const collectionLabels = {
       & > * {
         opacity: 0;
       }
+
+      &::before {
+        transition: opacity 300ms ease-in 1.5s;
+      }
     }
 
     & .overline {
       transform: translateY(-100%);
       transition: all 300ms ease-in 2s;
-    }
-
-    & .scrim {
-      transition: opacity 300ms ease-in 1.5s;
     }
 
     & .title {
@@ -185,10 +185,14 @@ const collectionLabels = {
       &.in {
         opacity: 1;
       }
-    }
 
-    .scrim {
-      z-index: -1;
+      &.out {
+        transition-delay: 1s;
+      }
+
+      &::before {
+        z-index: -1;
+      }
     }
 
     .overline {

--- a/site/src/components/Carousel.astro
+++ b/site/src/components/Carousel.astro
@@ -1,0 +1,191 @@
+---
+import { museumBaseUrl } from "@/lib/constants";
+import { getMode } from "@/lib/mode";
+import type { CollectionKey } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+  entries: ImageEntry[];
+}
+
+type ImageEntry =
+  | CollectionEntry<"blog">
+  | CollectionEntry<"exhibits">
+  | CollectionEntry<"products">;
+
+const { entries } = Astro.props;
+
+const collectionLabels: Partial<Record<CollectionKey, string>> = {
+  blog: "Post",
+  exhibits: "Exhibit",
+  products: "Merch",
+};
+---
+
+<div class:list={["carousel", getMode()]}>
+  {
+    entries.map((entry, i) => (
+      <div
+        class:list={["entry", !i && "in"]}
+        style={{ backgroundImage: `url(${entry.data.image.src})` }}
+        {...(i && getMode() === "fixed" && { inert: true })}
+      >
+        <div class="scrim" />
+        <div class="overline">Latest {collectionLabels[entry.collection]}</div>
+        <div class="title">{entry.data.title}</div>
+        <a
+          class="button"
+          href={`${museumBaseUrl}${entry.collection}/${entry.slug}/`}
+        >
+          Read more
+        </a>
+      </div>
+    ))
+  }
+</div>
+
+<script>
+  import { getMode } from "@/lib/mode";
+
+  const carousels = document.querySelectorAll(".carousel");
+
+  // TODO: fixed mode will need to be able to cancel/restart this
+  setInterval(() => {
+    carousels.forEach((el) => {
+      el.querySelector(".out")?.classList.toggle("out");
+      
+      const previousEl = el.querySelector(".in")!;
+      previousEl.classList.toggle("in");
+      previousEl.classList.toggle("out");
+      
+      const nextEl = previousEl.nextElementSibling || el.firstElementChild;
+      nextEl?.classList.toggle("in");
+      
+      if (getMode() === "fixed") {
+        (previousEl as HTMLElement).inert = true;
+        (nextEl as HTMLElement).inert = false;
+      }
+    });
+  }, 10000);
+</script>
+
+<style>
+  .carousel {
+    height: 80vh;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .entry {
+    background: center / cover no-repeat;
+    color: var(--white);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: calc(1rem * var(--ms5));
+    position: absolute;
+    inset: 0;
+    text-align: center;
+
+    &.in {
+      z-index: 2;
+    }
+
+    &.out {
+      z-index: 1;
+    }
+  }
+
+  .scrim {
+    background-color: rgba(0, 0, 0, 0.4);
+    position: absolute;
+    inset: 0;
+  }
+
+  .overline {
+    font-size: calc(1rem * var(--ms3));
+    letter-spacing: calc(1rem * var(--ms4));
+    text-transform: uppercase;
+  }
+
+  .title {
+    font-family: var(--title-font-family);
+    font-size: calc(1rem * var(--ms10));
+  }
+
+  a {
+    border-radius: 9999px;
+    padding: 1rem 2rem;
+    letter-spacing: calc(1rem * var(--ms3))
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  .broken {
+    .entry {
+      transition: transform 1s ease-in;
+      transform: translateX(100%);
+
+      & > * {
+        opacity: 0;
+      }
+    }
+
+    & .overline {
+      transform: translateY(-100%);
+      transition: all 300ms ease-in 2s;
+    }
+
+    & .scrim {
+      transition: opacity 300ms ease-in 1.5s;
+    }
+
+    & .title {
+      transform: scale(0.4);
+      transition: all 300ms ease-in 1.5s;
+    }
+
+    & a {
+      transform: translateY(100%);
+      transition: all 300ms ease-in 2.5s;
+    }
+
+    & .entry.in > * {
+      opacity: 1;
+    }
+
+    & .entry.out > * {
+      transition: opacity 300ms ease-in;
+    }
+
+    & .entry.in,
+    & .entry.out {
+      transform: translateX(0);
+
+      & .overline,
+      & a {
+        transform: translateY(0);
+      }
+
+      & .title {
+        transform: scale(1);
+      }
+    }
+  }
+
+  .fixed {
+    .entry {
+      transition: opacity 1s ease-in;
+      opacity: 0;
+
+      &.in {
+        opacity: 1;
+      }
+    }
+
+    .scrim {
+      z-index: -1;
+    }
+  }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -52,10 +52,14 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
 
     <MetaFailureSection href="museum/" title="Home">
       <dl slot="wcag2">
-        <dt>1.4.3: Contrast (Minimum)</dt>
+        <dt>1.3.2: Meaningful Sequence</dt>
         <dd>
-          Text overlaying images in the carousel does not include a background
-          to guarantee contrast.
+          The overline text over each title in the carousel uses space characters instead of letter-spacing,
+          changing their interpretation.
+        </dd>
+        <dt>1.4.6: Contrast (Enhanced)</dt>
+        <dd>
+          The scrim on the carousel is not always enough to guarantee sufficient contrast.
         </dd>
         <dt>2.2.2: Pause, Stop, Hide</dt>
         <dd>

--- a/site/src/pages/museum/blog/[category]/[post].astro
+++ b/site/src/pages/museum/blog/[category]/[post].astro
@@ -28,7 +28,7 @@ const dateFormat = new Intl.DateTimeFormat(["en-GB"], { dateStyle: "medium" });
 <Layout title={post.data.title} withInsetMain={false}>
   <article>
     <div
-      class="background"
+      class="background outset"
       style={{ backgroundImage: `url(${post.data.image.src})`, backgroundPosition: post.data.imagePosition }}
     >
       <header>
@@ -57,7 +57,6 @@ const dateFormat = new Intl.DateTimeFormat(["en-GB"], { dateStyle: "medium" });
   .background {
     background: fixed center / cover no-repeat;
     height: 50vh;
-    margin: 0 calc((100% - 100vw) / 2);
     position: relative;
   }
 

--- a/site/src/pages/museum/index.astro
+++ b/site/src/pages/museum/index.astro
@@ -2,6 +2,7 @@
 import { getCollection, getEntry } from "astro:content";
 import CoverImage from "@/components/CoverImage.astro";
 import Layout from "@/layouts/Layout.astro";
+import Carousel from "@/components/Carousel.astro";
 
 const featuredCategories = (await getCollection("exhibit-categories")).filter(
   ({ data }) => !!data.topDescription && !!data.topImageItem
@@ -16,9 +17,18 @@ const expandedCategories = await Promise.all(
     },
   }))
 );
+
+const carouselEntries = [
+  await getEntry("blog", "events/live-event"),
+  await getEntry("exhibits", "technology/crt-monitor"),
+  await getEntry("products", "vessels/water-bottle"),
+]
 ---
 
 <Layout title="Home">
+  <div class="outset">
+    <Carousel entries={carouselEntries} />
+  </div>
   <h2>Explore our Collections</h2>
   <div class="cards">
     {
@@ -96,5 +106,9 @@ const expandedCategories = await Promise.all(
     background: rgb(27, 27, 27, 0.03);
     border-top: 1px solid var(--hairline);
     padding: 0.5rem;
+  }
+
+  .outset {
+    margin-top: -1rem;
   }
 </style>


### PR DESCRIPTION
This adds a carousel to the top of the homepage, with the following properties in broken mode:

- Does not properly mark hidden items as inert, so they occupy tab stops even when not visible
  - Fixed mode adds `inert` to hidden items
- Includes motion/scale animations on the full entries and individual text items without honoring prefers-reduced-motion
  - Fixed mode only uses a fade animation on full entries and does not animate individual text items
- Lacks next/previous and pause/play controls
  - This is not yet addressed for fixed mode