### PR TITLE
Add background parallax to home category exhibits

### DIFF
--- a/site/src/content/exhibits/home/narrow-room.md
+++ b/site/src/content/exhibits/home/narrow-room.md
@@ -25,3 +25,32 @@ Illa mores frustra, resistite exemplis. Avos non latebris loco luridaque. Caecae
 acie victa delituit sorte freta Cytherea crescere rapit Iuppiter satis trahens.
 Gemunt cinctasque, dedisset instruxit spem concordare, hoc alto et mille de hos
 properata primus Gortyniaco delatus obituque dumque. Molibus est ne tangere.
+
+## Umero et e harenas rumpe telis
+
+Agenorides utque aequoris sortis; vate gestu meruisse admonita cervus Phineus!
+Nato ore rerum increvit, strepitans Iovis: flores hostibus sunt? Placetque res
+creamur ortus iuncique certa, talia tremens Cnidon.
+
+Solita meumque: fortuna ut medium femina constiterant sunt media sceleris
+Dictaeaque? Tamen murmure illa quod natantes ultima, levi mors rettulit vicimus
+silet quae prisco!
+
+## Vestem exclamat
+
+Quid moriturae iusta est pastoria Hactenus quodcumque splendida simul: victi ab.
+Nobilis nec optasse fregit Harpalos lacerans pulsa ultusque?
+
+## Auris Melicerta fluminea quem sollertia ignes praetemptat
+
+Cum Achillis nigra domos, diu temptant quid tuli. Sic moras querno traderet
+cultros mactare saxum currum etsi vina. Illi opus pars mansura laetus remissis
+quam: via ac saxo corporis dirimant, Acrisioneas patris.
+
+Corpus Pentheus, focus spiramenta radicibus parenti faciunt, creatus auras. Per
+sororem obstipuere est mente gaudent in nubila freta penates in rutilum
+furibunda, pater? Prospiciunt operis domus, metuens, sic tela aure cogitat
+iuvenum torquet centum amissoque!
+
+Iamque caelicolae ibat tandem viri sextae et mater latentia annos. Latuerunt
+accendit aerias inposuit arbor cepit?

--- a/site/src/content/exhibits/home/porch-chair.md
+++ b/site/src/content/exhibits/home/porch-chair.md
@@ -17,3 +17,35 @@ quanto Tiberinus trunci.
 
 Infelix nervis, sic modo ut mirum iam hunc, hoc. Constitit traduxit flammis
 pharetrae succeditis vada igne corpore tuentur languescuntque superbia.
+
+## Rupit una sedit tangere qui signaque vidi
+
+Lorem markdownum, tibi summis noster undas nemorisque ora ergo coronatis? Monet
+ab facunde canoro nemorum ipse, non totiens, tibi virgineos facit fallaciter
+gratamque fletibus summa.
+
+Qua ibi truces dextera quod aequales quas iactatibus hastis vale fidissime
+reliquit et sponsa exigua. Hostisque damnavit; et eadem mox demitteret te
+monstra imitata. Ait data et ego erat colentes ferebat plangitur consonus rogant
+suis venias silva spectat Cynthia, Amathunta repetemus illa. Fuit et tibi
+blandimenta iuste adnuit vixi, boum gelidae, noctis?
+
+Pro ne hunc ipse stamine occidit piget, adhuc nova fulmina hausit viribus
+submovet erat gravem. Semina decerpsit norint sacerdos cita prodita, pallentia
+saepe queruntur quondam seque et corpore ore existit mittat. Dixit numquam
+Arcesius celeremque certe, cum zonam imagine permulcet demptos erat quidem cum
+latera. Pario suis invita iamque Iovis interea passis? Erit vix Arcas quid inter
+negate indicat quercus seu, illi illam aliqua facinus; parabant.
+
+## Qui raucis vetat miser Agenorides tactosque catenas
+
+Protinus non oris, promissis hamos taedia et, erepta mihi extenuatur. Talia
+Chrysenque Sibyllae prima. Formamque bene demum Boreas duxere quae litorei
+gradus voce picta est membris. Locis qui visae, visa munus, cum quoque crines
+flamma minimus conchae intima ne gradus fulmen frater inflata iussit! Meque nisi
+vulgus flavescit more.
+
+Diva ludit, et metu Cepheusque quas quietem cur murice dicere, fortis geruntur
+parva inquit verba. Columbas inpune Hylonome hastarum genus sinuatoque restabat
+scire turris, carituraque adsueta exhalata? Morae Gangetica irascere dedisset
+Palaestini natum.

--- a/site/src/content/exhibits/home/wide-bedroom.md
+++ b/site/src/content/exhibits/home/wide-bedroom.md
@@ -15,3 +15,14 @@ tua retinente gentis auctore canenti videri visa huc, circumdata se femina
 emensas? Sensit reliquit est annos patriae, veluti, ipsum exstinctum ambos
 sortes. Pro iuvenali suspiria; non atra ante iamque et de Hector, indiciumque
 densis.
+
+## Et currat doloris in exiles iacentia Haedis
+
+Ore intorquet origo, illi ipso meliora tellus, terram toro deus. Est quod sit
+omnis cecidit potuissent superabit cecidit est: et natae quod nequeunt corvo
+adice occupat. Attollo fugiens in quod bono vires tempora Priamidenque matre
+caput inventa ora? Non quod, tegit satis reficisque commisit, comitem: cepit
+fera hoc, manet sinuataque aurea conclamat. Summum validisne dextera ilice.
+
+Quae iunguntur et possim sinu concubitus erit nepotis angues dextro altis dedit
+pariter omnes et fuerat. Querellis latet.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -80,6 +80,10 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           The image thumbnails in the exhibit list on this page flash 4 times within a one-second period.
         </dd>
+        <dt>2.3.3: Animation from Interactions</dt>
+        <dd>
+          Each individual exhibit page under the Home collection includes a parallax effect on the background image.
+        </dd>
       </dl>
     </MetaFailureSection>
 

--- a/site/src/pages/museum/collections/[category]/[exhibit].astro
+++ b/site/src/pages/museum/collections/[category]/[exhibit].astro
@@ -1,47 +1,84 @@
 ---
-import { getCollection } from "astro:content";
+import { type CollectionEntry, getCollection } from "astro:content";
+import CoverImage from "@/components/CoverImage.astro";
+import Layout from "@/layouts/Layout.astro";
+import { getEntry } from "astro:content";
 
 export async function getStaticPaths() {
   const allExhibits = await getCollection("exhibits");
 
-  return allExhibits.map((exhibit) => {
-    const [category, exhibitSlug] = exhibit.slug.split("/");
-    return {
-      params: { category, exhibit: exhibitSlug },
-      props: { exhibit },
-    };
-  });
+  return Promise.all(
+    allExhibits.map(async (exhibit) => {
+      const [categorySlug, exhibitSlug] = exhibit.slug.split("/");
+      return {
+        params: { category: categorySlug, exhibit: exhibitSlug },
+        props: {
+          category: await getEntry("exhibit-categories", categorySlug),
+          exhibit,
+        },
+      };
+    })
+  );
 }
-
-import type { CollectionEntry } from "astro:content";
-import Layout from "@/layouts/Layout.astro";
-import CoverImage from "@/components/CoverImage.astro";
 
 interface Props {
+  category: CollectionEntry<"exhibit-categories">;
   exhibit: CollectionEntry<"exhibits">;
-  title: string;
 }
 
-const { exhibit } = Astro.props;
+const { category, exhibit } = Astro.props;
 const { Content } = await exhibit.render();
 ---
 
-<Layout title={exhibit.data.title}>
-  <h1>{exhibit.data.title}</h1>
-  <div class="container">
-    <div class="image-container">
-      <CoverImage
-        src={exhibit.data.image}
-        alt={exhibit.data.skipAlt ? null : exhibit.data.imageDescription}
-        objectPosition={exhibit.data.imagePosition}
-        widths={[960]}
-      />
-    </div>
-    <div class="content">
-      <Content />
-    </div>
-  </div>
+<Layout title={exhibit.data.title} withInsetMain={!category.data.dangerous}>
+  {
+    category.data.dangerous ? (
+      <div
+        class="dangerous"
+        style={{ background: `url(${exhibit.data.image.src})` }}
+      >
+        <h1>{exhibit.data.title}</h1>
+        <Content />
+      </div>
+    ) : (
+      <>
+        <h1>{exhibit.data.title}</h1>
+        <div class="container">
+          <div class="image-container">
+            <CoverImage
+              src={exhibit.data.image}
+              alt={exhibit.data.skipAlt ? null : exhibit.data.imageDescription}
+              objectPosition={exhibit.data.imagePosition}
+              widths={[960]}
+            />
+          </div>
+          <div class="content">
+            <Content />
+          </div>
+        </div>
+      </>
+    )
+  }
 </Layout>
+
+<script>
+  import throttle from "lodash-es/throttle";
+  import { getMode } from "@/lib/mode";
+
+  const dangerousEl = document.querySelector(".dangerous");
+  if (dangerousEl && getMode() === "broken") {
+    const docEl = document.documentElement;
+    const updateScroll = throttle(() => {
+      const scrollPercentage =
+        docEl.scrollTop / (docEl.scrollHeight - window.innerHeight);
+      (dangerousEl as HTMLElement).style.backgroundPositionY =
+        `${scrollPercentage * 100}%`;
+    });
+
+    window.addEventListener("resize", updateScroll);
+    window.addEventListener("scroll", updateScroll);
+  }
+</script>
 
 <style>
   h1 {
@@ -71,6 +108,52 @@ const { Content } = await exhibit.render();
 
     & img {
       max-width: 100%;
+    }
+  }
+
+  .dangerous {
+    background: fixed center top / cover no-repeat;
+    color: var(--white);
+    padding: 1rem 10%;
+    position: relative;
+
+    &::before {
+      background: linear-gradient(
+        to right,
+        rgba(0, 0, 0, 0.1) 0%,
+        rgba(0, 0, 0, 0.7) 12%,
+        rgba(0, 0, 0, 0.7) 88%,
+        rgba(0, 0, 0, 0.1) 100%
+      );
+      position: absolute;
+      inset: 0;
+      content: "";
+    }
+
+    & h1 {
+      margin: 0;
+      text-align: left;
+    }
+
+    /* Global selector required because <Content /> doesn't get scoped */
+    & :global(> *) {
+      position: relative; /* force stacking context for z order */
+    }
+  }
+
+  @media (min-width: 60em) {
+    .dangerous {
+      padding: 1rem 40% 1rem 10%;
+
+      &::before {
+        background: linear-gradient(
+          to right,
+          rgba(0, 0, 0, 0.1) 0%,
+          rgba(0, 0, 0, 0.7) 8%,
+          rgba(0, 0, 0, 0.7) 52%,
+          rgba(0, 0, 0, 0.1) 75%
+        );
+      }
     }
   }
 </style>


### PR DESCRIPTION
This is follow-up to #30, adding parallax effect to the background on individual exhibit pages in the home collection.

- Adds alternate rendering to the exhibit page for "dangerous" collections (only the Home collection is marked dangerous; this is the same flag used for the flashing effects in #30)
- Adds more content to the Home entries to ensure a noticeable range of parallax motion while also trying to avoid being extremely fast
- The warning modal on the collection page already mentions these pages having parallax