### PR TITLE
Add masonry to collections list page

### DIFF
--- a/site/src/lib/image.ts
+++ b/site/src/lib/image.ts
@@ -1,0 +1,21 @@
+import { getImage } from "astro:assets";
+import type { ImageFunction, z } from "astro:content";
+
+/**
+ * Downsizes an image by using getImage, returning its src attribute.
+ * Useful in specific cases where we want the image to determine
+ * its own width/height or scale preserving its aspect ratio,
+ * which <Image /> does not allow.
+ */
+export async function getDownsizedSrc(
+  image: z.infer<ReturnType<ImageFunction>>,
+  width: number
+) {
+  const result = await getImage({
+    src: image,
+    // Use getImage's srcSet functionality to downsize
+    widths: [width],
+  });
+  // Pull downsized image URL out of returned srcSet
+  return result.srcSet.attribute.split(" ")[0];
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -64,6 +64,29 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       </dl>
     </MetaFailureSection>
 
+    <MetaFailureSection href="museum/collections/" title="Collections">
+      <dl slot="wcag2">
+        <dt>1.4.13: Content on Hover or Focus</dt>
+        <dd>
+          The text label on each collection's link only becomes visible on hover (not focus).
+        </dd>
+        <dt>2.4.3: Focus Order</dt>
+        <dd>
+          The collection links have explicit tabindex attributes, causing them to come before
+          anything else in the page. The links in the "See More" section are
+          not included in this explicit order, meaning focus tabs to each collection link,
+          then header items, then the "See More" links, then the footer.
+          Moreover, the explicit tab order is optimized specifically for the widest
+          layout, making it incorrect even within the collections list on narrower viewports.
+        </dd>
+        <dt>3.2.3: Consistent Navigation</dt>
+        <dd>
+          The links that appear within the "See More" section within the main content
+          are removed from the header navigation where they otherwise typically appear.
+        </dd>
+      </dl>
+    </MetaFailureSection>
+
     <MetaFailureSection href="museum/collections/dishes/" title="Dishes Collection">
       <dl slot="wcag2">
         <dt>1.1.1: Non-text Content</dt>

--- a/site/src/pages/museum/collections/index.astro
+++ b/site/src/pages/museum/collections/index.astro
@@ -1,23 +1,148 @@
 ---
-import { getCollection } from "astro:content";
+import { type CollectionEntry, getCollection } from "astro:content";
+import { sortBy, uniqBy } from "lodash-es";
+import Fixable from "@/components/Fixable.astro";
 import Layout from "@/layouts/Layout.astro";
-import { sortBy } from "lodash-es";
+import { getDownsizedSrc } from "@/lib/image";
+import { defaultNavLinks } from "@/lib/nav-links";
 
 const categories = sortBy(
-  (await getCollection("exhibit-categories")).filter(({ data }) => !data.dangerous),
+  (await getCollection("exhibit-categories")).filter(
+    ({ data }) => !data.dangerous
+  ),
   ({ data }) => data.title
+);
+
+const exhibits = uniqBy(
+  await getCollection("exhibits"),
+  ({ slug }) => slug.split("/")[0]
+);
+
+const exhibitsMap = {} as Record<
+  CollectionEntry<"exhibit-categories">["slug"],
+  CollectionEntry<"exhibits">["data"] & { downsizedSrc: string }
+>;
+
+for (const { data, slug } of exhibits) {
+  exhibitsMap[slug.split("/")[0]] = {
+    ...data,
+    downsizedSrc: await getDownsizedSrc(data.image, 480),
+  };
+}
+
+// Hard-code tabindices based on widest layout
+// (this is far easier than writing dynamic JS logic
+// which we would intentionally want to break anyway)
+const tabIndices = [1, 2, 4, 6, 3, 5, 7];
+
+const seeMoreLabels = ["Blog", "Gift Shop"];
+const seeMoreLinks = defaultNavLinks.filter(({ name }) =>
+  seeMoreLabels.includes(name)
+);
+const headerNavLinks = defaultNavLinks.filter(
+  ({ name }) => !seeMoreLabels.includes(name)
 );
 ---
 
-<Layout title="Collections">
+<Layout title="Collections" {headerNavLinks}>
   <h2>Our Collections</h2>
-  <ul class="list-group list-group-flush">
+  <ul>
     {
-      categories.map(({ data, slug }) => (
-        <li class="list-group-item">
-          <a href={`${slug}/`} set:text={data.title} />
-        </li>
+      categories.map(({ data, slug }, i) => (
+        <>
+          <li>
+            <Fixable
+              as="a"
+              href={`${slug}/`}
+              broken={{ tabindex: tabIndices[i] }}
+            >
+              {/* Reference the downsized optimized image */}
+              <img src={exhibitsMap[slug].downsizedSrc} alt="" />
+              <span class="label">{data.title}</span>
+            </Fixable>
+          </li>
+          {i === 5 && (
+            <li class="see-more">
+              <h2>See More</h2>
+              {seeMoreLinks.map(({ href, name }) => (
+                <a class="button" {href}>
+                  {name}
+                </a>
+              ))}
+            </li>
+          )}
+        </>
       ))
     }
   </ul>
 </Layout>
+
+<style>
+  ul {
+    columns: 2;
+    column-gap: 1rem;
+    list-style: none;
+  }
+
+  @media (min-width: 30em) {
+    ul {
+      columns: 3;
+    }
+  }
+
+  @media (min-width: 60em) {
+    ul {
+      columns: 4;
+    }
+  }
+
+  li {
+    margin-bottom: 1rem;
+  }
+
+  a:has(img) {
+    color: var(--white);
+    display: block;
+    font-family: var(--title-font-family);
+    font-size: calc(1rem * var(--ms5));
+    outline-offset: 1px;
+    position: relative;
+    text-decoration: none;
+
+    & img {
+      display: block;
+      width: 100%;
+    }
+
+    &:hover .label {
+      opacity: 1;
+    }
+  }
+
+  .label {
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    position: absolute;
+    inset: 0;
+    text-align: center;
+    transition: opacity 200ms;
+  }
+
+  .see-more {
+    background-color: var(--gold-vivid-050);
+    break-inside: avoid;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: stretch;
+    padding: 1rem;
+
+    & > * {
+      margin: 0;
+      text-align: center;
+    }
+  }
+</style>


### PR DESCRIPTION
This updates the page at /fixable/museum/collections, which we hadn't really paid much attention to.

- Adds masonry layout with images for each collection (using the first entry found for each category)
- Each link's text only visibly appears on hover (not focus)
- Explicit tabindex attributes are used on the masonry layout links
  - This makes them occur before even header content in tab order
  - The links within "See More" are not included in this explicit ordering
  - The order is hard-coded against the widest layout, meaning it is further incorrect even within the collection links on narrower viewports
- The "See More" box includes links that are "moved" out of the header nav

Other code changes:

- Created a helper function under lib/image for instances where we want a downsampled image but don't want to be held to the Astro Image component's assumptions (e.g. forcing width/height to the original image's full dimensions)