### PR TITLE
Add Favorite toggle to individual exhibit pages

### DIFF
--- a/site/src/components/Favorite.astro
+++ b/site/src/components/Favorite.astro
@@ -1,0 +1,83 @@
+---
+import { Icon } from "astro-icon/components";
+import FixableRegion from "./FixableRegion.astro";
+
+interface Props {
+  id: string;
+  size?: number;
+}
+
+const { id, size = 48 } = Astro.props;
+---
+
+<FixableRegion>
+  <div class="favorite broken" id={`favorite-${id}`}>
+    <Icon name="ri:heart-line" class="off" {size} />
+    <Icon name="ri:heart-fill" class="on" {size} />
+  </div>
+  <button
+    slot="fixed"
+    class="favorite"
+    id={`favorite-${id}`}
+    role="checkbox"
+    aria-checked="false"
+  >
+    <Icon name="ri:heart-line" {size} />
+    <Icon name="ri:heart-fill" {size} />
+    <span class="visually-hidden">Favorite</span>
+  </button>
+</FixableRegion>
+
+<script>
+  import { onStoreChange, persist, recall } from "@/lib/client/store";
+
+  onStoreChange("favorites", (favorites, oldFavorites) => {
+    for (const [key, value] of Object.entries(favorites)) {
+      if (oldFavorites && oldFavorites?.[key] === favorites[key]) continue;
+
+      const el = document.getElementById(`favorite-${key}`) as HTMLElement;
+      if (el.tagName === "BUTTON") el.setAttribute("aria-checked", "" + value);
+      else el.classList.toggle("added", value);
+    }
+  });
+
+  document.body.addEventListener("click", (event) => {
+    const el = (event.target as HTMLElement).closest(
+      ".favorite[id^='favorite-']"
+    );
+    if (!el) return;
+
+    const key = el.id.slice(9);
+    persist("favorites", {
+      [key]: !recall("favorites")[key],
+    });
+  });
+</script>
+
+<style>
+  .favorite {
+    color: var(--red-warm-500);
+
+    &:hover {
+      color: var(--red-warm-400);
+    }
+
+    &.broken {
+      &:not(.added) svg:last-of-type,
+      &.added svg:first-of-type {
+        display: none;
+      }
+    }
+
+    &[role="checkbox"] {
+      background: none;
+      border: none;
+      padding: 0;
+
+      &[aria-checked="false"] svg:last-of-type,
+      &[aria-checked="true"] svg:first-of-type {
+        display: none;
+      }
+    }
+  }
+</style>

--- a/site/src/components/Favorite.astro
+++ b/site/src/components/Favorite.astro
@@ -35,7 +35,8 @@ const { id, size = 48 } = Astro.props;
     for (const [key, value] of Object.entries(favorites)) {
       if (oldFavorites && oldFavorites?.[key] === favorites[key]) continue;
 
-      const el = document.getElementById(`favorite-${key}`) as HTMLElement;
+      const el = document.getElementById(`favorite-${key}`) as HTMLElement | null;
+      if (!el) continue;
       if (el.tagName === "BUTTON") el.setAttribute("aria-checked", "" + value);
       else el.classList.toggle("added", value);
     }
@@ -48,18 +49,20 @@ const { id, size = 48 } = Astro.props;
     if (!el) return;
 
     const key = el.id.slice(9);
+    const oldFavorites = recall("favorites");
     persist("favorites", {
-      [key]: !recall("favorites")[key],
+      ...oldFavorites,
+      [key]: !oldFavorites[key],
     });
   });
 </script>
 
 <style>
   .favorite {
-    color: var(--red-warm-500);
+    color: var(--gold-vivid-200);
 
     &:hover {
-      color: var(--red-warm-400);
+      color: var(--gold-vivid-100);
     }
 
     &.broken {

--- a/site/src/lib/client/store.ts
+++ b/site/src/lib/client/store.ts
@@ -19,6 +19,7 @@ export const storeSchema = z.object({
       })
     )
     .default({}),
+  favorites: z.record(z.string(), z.boolean()).default({}),
   loggedInAt: z.string().datetime().nullable().default(null),
   registration: z.object({
     email: z.string().email(),

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -123,6 +123,19 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       </dl>
     </MetaFailureSection>
 
+    <MetaFailureSection href="museum/collections/containers/ceramic-vase/" title="Exhibit Pages">
+      <dl slot="wcag2">
+        <dt>1.3.6: Identify Purpose</dt>
+        <dd>
+          The favorite toggle does not programmatically indicate that it accepts input.
+        </dd>
+        <dt>2.1.1 and 2.1.3: Keyboard</dt>
+        <dd>
+          The Favorite toggle is not accessible via keyboard.
+        </dd>
+      </dl>
+    </MetaFailureSection>
+
     <MetaFailureSection href="museum/tour/" title="Take a Tour">
       <dl slot="wcag2">
         <dt>2.2.4: Interruptions</dt>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -123,11 +123,16 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       </dl>
     </MetaFailureSection>
 
-    <MetaFailureSection href="museum/collections/containers/ceramic-vase/" title="Exhibit Pages">
+    <MetaFailureSection href="museum/collections/containers/clay-jug/" title="Exhibit Pages">
       <dl slot="wcag2">
         <dt>1.3.6: Identify Purpose</dt>
         <dd>
           The favorite toggle does not programmatically indicate that it accepts input.
+        </dd>
+        <dt>1.4.11: Non-text Contrast</dt>
+        <dd>
+          The favorite icon uses a color that does not always maintain sufficient contrast with the background
+          (the particular exhibit linked above is one such example).
         </dd>
         <dt>2.1.1 and 2.1.3: Keyboard</dt>
         <dd>

--- a/site/src/pages/museum/collections/[category]/[exhibit].astro
+++ b/site/src/pages/museum/collections/[category]/[exhibit].astro
@@ -1,6 +1,7 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
 import CoverImage from "@/components/CoverImage.astro";
+import Favorite from "@/components/Favorite.astro";
 import Layout from "@/layouts/Layout.astro";
 import { getEntry } from "astro:content";
 
@@ -39,6 +40,9 @@ const { Content } = await exhibit.render();
       >
         <h1>{exhibit.data.title}</h1>
         <Content />
+        <div class="favorite-container">
+          <Favorite id={exhibit.slug} />
+        </div>
       </div>
     ) : (
       <>
@@ -51,6 +55,9 @@ const { Content } = await exhibit.render();
               objectPosition={exhibit.data.imagePosition}
               widths={[960]}
             />
+            <div class="favorite-container">
+              <Favorite id={exhibit.slug} />
+            </div>
           </div>
           <div class="content">
             <Content />
@@ -105,6 +112,7 @@ const { Content } = await exhibit.render();
   .image-container {
     display: flex;
     align-items: flex-start;
+    position: relative;
 
     & img {
       max-width: 100%;
@@ -155,5 +163,11 @@ const { Content } = await exhibit.render();
         );
       }
     }
+  }
+
+  .favorite-container {
+    position: absolute;
+    right: 1rem;
+    top: 1rem;
   }
 </style>


### PR DESCRIPTION
This adds an icon overlaying the top-right corner of each exhibit's image on individual exhibit pages. Clicking the icon toggles persistent state that is maintained individually for each exhibit.

- The broken version uses a div with no programmatic indication of it being interactive and no tab stop
- The fixed version uses a button with role="checkbox" and aria-checked, though I imagine there could be several ways to go about this and maybe something else is preferable?

Things I intentionally did not do in this PR:

- I did not make this reveal only on hover, because that might make the other issues too easy to overlook
- I did not add this to grid cells in each collection listing, because I already have thoughts about something we can do on top of that (namely making each entire cell a link) and don't want to overload it too much (though maybe that would be something we're interested in doing?)

Another thing I could do on top of this in a future PR, if desired, is add some kind of toast confirmation (optionally with an undo CTA); I'm sure there are things something like that could fail...