### PR TITLE
Include exhibit images within links on music collection page

### DIFF
--- a/site/src/components/ConditionalParent.astro
+++ b/site/src/components/ConditionalParent.astro
@@ -1,0 +1,32 @@
+---
+/**
+ * @fileoverview
+ * Component that allows conditionally rendering a parent without repeating children.
+ */
+import type { ComponentProps, HTMLTag, Polymorphic } from "astro/types";
+
+type Props<Tag extends HTMLTag | AstroComponent> = {
+  if: boolean;
+} & (Tag extends HTMLTag
+  ? Polymorphic<{ as: Tag }>
+  : Tag extends AstroComponent
+    ? // This second ternary is required to pass type checking but the `never` will never occur
+      ComponentProps<Tag> & {
+        as: Tag;
+      }
+    : never);
+
+type AstroComponent = (args: any) => any;
+
+const { as: Tag, if: condition, ...props } = Astro.props;
+---
+
+{
+  condition ? (
+    <Tag {...props}>
+      <slot />
+    </Tag>
+  ) : (
+    <slot />
+  )
+}

--- a/site/src/components/ConditionalParent.astro
+++ b/site/src/components/ConditionalParent.astro
@@ -3,20 +3,11 @@
  * @fileoverview
  * Component that allows conditionally rendering a parent without repeating children.
  */
-import type { ComponentProps, HTMLTag, Polymorphic } from "astro/types";
+import type { PolymorphicProps, TagOrComponent } from "./types";
 
-type Props<Tag extends HTMLTag | AstroComponent> = {
+type Props<Tag extends TagOrComponent> = PolymorphicProps<Tag> & {
   if: boolean;
-} & (Tag extends HTMLTag
-  ? Polymorphic<{ as: Tag }>
-  : Tag extends AstroComponent
-    ? // This second ternary is required to pass type checking but the `never` will never occur
-      ComponentProps<Tag> & {
-        as: Tag;
-      }
-    : never);
-
-type AstroComponent = (args: any) => any;
+};
 
 const { as: Tag, if: condition, ...props } = Astro.props;
 ---

--- a/site/src/components/Fixable.astro
+++ b/site/src/components/Fixable.astro
@@ -5,32 +5,21 @@
  * property; props common to both states can be specified top-level as usual.
  */
 
-import type { ComponentProps, HTMLTag, Polymorphic } from "astro/types";
 import { getMode } from "@/lib/mode";
+import type { PolymorphicProps, TagOrComponent } from "./types";
 
 const mode = getMode();
 
-// NOTE: Props _needs_ to be the first declared type for Astro to process correctly
+// Note(ken): & { as: never } below is designed to prevent setting `as`
+// within broken/fixed, which the component does not support.
+// Using Omit would be ideal, but causes TS complexity errors in this case.
 
-type Props<Tag extends HTMLTag | AstroComponent> = Tag extends HTMLTag
-  ? Polymorphic<{ as: Tag }> &
-      SpecialCaseProps<Partial<Omit<Polymorphic<{ as: Tag }>, "as">>>
-  : Tag extends AstroComponent
-    ? // This second ternary is required to pass type checking but the `never` will never occur
-      ComponentProps<Tag> &
-        SpecialCaseProps<Partial<ComponentProps<Tag>>> & {
-          as: Tag;
-        }
-    : never;
-
-type AstroComponent = (args: any) => any;
-
-type SpecialCaseProps<T> = {
+type Props<Tag extends TagOrComponent> = PolymorphicProps<Tag> & {
   /** Any attributes that should only be set on the broken version */
-  broken?: T;
+  broken?: Partial<PolymorphicProps<Tag> & { as: never }>;
   /** Any attributes that should only be set on the fixed version */
-  fixed?: T;
-};
+  fixed?: Partial<PolymorphicProps<Tag> & { as: never }>;
+}
 
 const { as: Tag, broken, fixed, ...props } = Astro.props;
 ---

--- a/site/src/components/types.ts
+++ b/site/src/components/types.ts
@@ -1,0 +1,20 @@
+/** @fileoverview Common types useful across components */
+
+import type { ComponentProps, HTMLTag, Polymorphic } from "astro/types";
+
+type AstroComponent = (args: any) => any;
+
+export type TagOrComponent = HTMLTag | AstroComponent;
+
+/**
+ * Extension to Astro's Polymorphic type to support either a native element or component.
+ */
+export type PolymorphicProps<Tag extends TagOrComponent> =
+  Tag extends HTMLTag
+    ? Polymorphic<{ as: Tag }>
+    : Tag extends AstroComponent
+      ? // This second ternary is required to pass type checking but the `never` will never occur
+        ComponentProps<Tag> & {
+          as: Tag;
+        }
+      : never;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -114,6 +114,23 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       </dl>
     </MetaFailureSection>
 
+    <MetaFailureSection href="museum/collections/music/" title="Music Collection">
+      <dl slot="wcag2">
+        <dt>2.4.4 and 2.4.9: Link Purpose</dt>
+        <dd>
+          The purpose of each entry's link is unclear because its image (with alt text)
+          is also included within the link, preceding its title.
+        </dd>
+      </dl>
+      <dl slot="wcag3">
+        <dt>Interface Verbosity</dt>
+        <dd>
+          The link for each entry is overly verbose, due to the inclusion of
+          each entry's image (with alt text).
+        </dd>
+      </dl>
+    </MetaFailureSection>
+
     <MetaFailureSection href="museum/collections/technology/" title="Technology Collection">
       <dl slot="wcag2">
         <dt>1.1.1: Non-text Content</dt>

--- a/site/src/pages/museum/collections/[category]/index.astro
+++ b/site/src/pages/museum/collections/[category]/index.astro
@@ -31,6 +31,8 @@ export async function getStaticPaths() {
 
 const { category, exhibits } = Astro.props;
 const { Content } = await category.render();
+
+const shouldWrapImageInLink = getMode() === "broken" && category.slug === "music";
 ---
 
 <Layout title={category.data.title}>
@@ -74,7 +76,7 @@ const { Content } = await category.render();
         <li>
           <ConditionalParent
             as="a"
-            if={getMode() === "broken"}
+            if={shouldWrapImageInLink}
             href={`../${slug}/`}
           >
             <div class="image-container">
@@ -89,7 +91,7 @@ const { Content } = await category.render();
             <div class="content">
               <ConditionalParent
                 as="a"
-                if={getMode() === "fixed"}
+                if={!shouldWrapImageInLink}
                 href={`../${slug}/`}
               >
                 {data.title}

--- a/site/src/pages/museum/collections/[category]/index.astro
+++ b/site/src/pages/museum/collections/[category]/index.astro
@@ -1,10 +1,12 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
 import { sortBy } from "lodash-es";
+import ConditionalParent from "@/components/ConditionalParent.astro";
 import CoverImage from "@/components/CoverImage.astro";
 import Modal from "@/components/Modal.astro";
 import Layout from "@/layouts/Layout.astro";
 import { museumBaseUrl } from "@/lib/constants";
+import { getMode } from "@/lib/mode";
 
 interface Props {
   category: CollectionEntry<"exhibit-categories">;
@@ -70,18 +72,30 @@ const { Content } = await category.render();
     {
       exhibits.map(({ data, slug }) => (
         <li>
-          <div class="image-container">
-            <CoverImage
-              src={data.image}
-              alt={data.skipAlt ? null : data.imageDescription}
-              objectPosition={data.imagePosition}
-              height="200"
-              widths={[960]}
-            />
-          </div>
-          <div class="content">
-            <a href={`../${slug}/`}>{data.title}</a>
-          </div>
+          <ConditionalParent
+            as="a"
+            if={getMode() === "broken"}
+            href={`../${slug}/`}
+          >
+            <div class="image-container">
+              <CoverImage
+                src={data.image}
+                alt={data.skipAlt ? null : data.imageDescription}
+                objectPosition={data.imagePosition}
+                height="200"
+                widths={[960]}
+              />
+            </div>
+            <div class="content">
+              <ConditionalParent
+                as="a"
+                if={getMode() === "fixed"}
+                href={`../${slug}/`}
+              >
+                {data.title}
+              </ConditionalParent>
+            </div>
+          </ConditionalParent>
         </li>
       ))
     }
@@ -99,10 +113,9 @@ const { Content } = await category.render();
     form.addEventListener("submit", (event) => {
       const value = (event.submitter as HTMLButtonElement).value;
       const listEl = document.getElementById("list") as HTMLUListElement;
-      if (value.startsWith("A"))
-        listEl.classList.add("dangerous-list");
+      if (value.startsWith("A")) listEl.classList.add("dangerous-list");
       if (value === "A") listEl.classList.add("dangerous-list-A");
-      if (value === "none") listEl.classList.add("fading-list")
+      if (value === "none") listEl.classList.add("fading-list");
     });
   }
 </script>
@@ -170,7 +183,8 @@ const { Content } = await category.render();
     animation: linear 3s infinite fade;
   }
 
-  .content a {
+  .content a,
+  .content:not(:has(a)) {
     display: block;
     padding: 1rem;
     text-align: center;


### PR DESCRIPTION
The main goal of this PR is to cause failures due to overly-verbose links that bury the important part at the end, by wrapping images (with alt text) within links on one collection's list of exhibits, thus achieving the effect of a common "card" anti-pattern.

This PR also includes some refactoring of typings, since I added a `ConditionalParent` component to make conditional wrappers easier, which relies on similar typings to what `Fixable` already used. (The code removed from `Fixable` now exists in `components/types.ts`.)