### PR TITLE
Worsen the opening hours table

### DIFF
--- a/site/src/pages/museum/about.astro
+++ b/site/src/pages/museum/about.astro
@@ -71,7 +71,7 @@ const headerNavLinks =
         <div class="cell" role="cell">9-5</div>
       </div>
       <div class="row" role="row">
-        <div class="cell" role="columnheader">Sat</div>
+        <div class="cell" role="columnheader">Fri</div>
         <div class="cell" role="cell">9-5</div>
       </div>
       <div class="row" role="row">

--- a/site/src/pages/museum/about.astro
+++ b/site/src/pages/museum/about.astro
@@ -207,6 +207,7 @@ const headerNavLinks =
   }
 
   .cell {
+    align-items: center;
     display: flex;
     flex: 1;
     place-content: center;

--- a/site/src/pages/museum/about.astro
+++ b/site/src/pages/museum/about.astro
@@ -177,16 +177,16 @@ const headerNavLinks =
     border: 1px solid #000;
   }
 
-  .table__responsive {
+  .table__desktop {
     display: none;
   }
 
-  @media (width <=700px) {
-    .table__desktop {
+  @media (min-width: 30em) {
+    .table__responsive {
       display: none;
     }
 
-    .table__responsive {
+    .table__desktop {
       display: block;
     }
   }

--- a/site/src/pages/museum/about.astro
+++ b/site/src/pages/museum/about.astro
@@ -75,7 +75,7 @@ const headerNavLinks =
         <div class="cell" role="cell">9-5</div>
       </div>
       <div class="row" role="row">
-        <div class="cell" role="columnheader">Sun</div>
+        <div class="cell" role="columnheader">Sat</div>
         <div class="cell" role="cell">9-5</div>
       </div>
       <div class="row" role="row">

--- a/site/src/pages/museum/about.astro
+++ b/site/src/pages/museum/about.astro
@@ -32,24 +32,55 @@ const headerNavLinks =
 
     <h2 class="masked hours"><span>Opening Hours</span></h2>
 
-    <div class="table">
-      <div class="row heading">
-        <div class="cell">Mon</div>
-        <div class="cell">Tue</div>
-        <div class="cell">Wed</div>
-        <div class="cell">Thu</div>
-        <div class="cell">Fri</div>
-        <div class="cell">Sat</div>
-        <div class="cell">Sun</div>
+    <div class="table__desktop" role="grid">
+      <div class="row" role="row">
+        <div class="cell" role="columnheader">Mon</div>
+        <div class="cell" role="columnheader">Tue</div>
+        <div class="cell" role="columnheader">Wed</div>
+        <div class="cell" role="columnheader">Thu</div>
+        <div class="cell" role="columnheader">Fri</div>
+        <div class="cell" role="columnheader">Sat</div>
+        <div class="cell" role="columnheader">Sun</div>
       </div>
-      <div class="row">
-        <div class="cell">9-5</div>
-        <div class="cell">9-5</div>
-        <div class="cell">9-5</div>
-        <div class="cell">9-5</div>
-        <div class="cell">9-5</div>
-        <div class="cell">8-8</div>
-        <div class="cell">9-8</div>
+      <div class="row" role="row">
+        <div class="cell" role="cell">9-5</div>
+        <div class="cell" role="cell">9-5</div>
+        <div class="cell" role="cell">9-5</div>
+        <div class="cell" role="cell">9-5</div>
+        <div class="cell" role="cell">9-5</div>
+        <div class="cell" role="cell">8-8</div>
+        <div class="cell" role="cell">9-8</div>
+      </div>
+    </div>
+
+    <div class="table__responsive" role="grid">
+      <div class="row" role="row">
+        <div class="cell" role="columnheader">Mon</div>
+        <div class="cell" role="cell">9-5</div>
+      </div>
+      <div class="row" role="row">
+        <div class="cell" role="columnheader">Tue</div>
+        <div class="cell" role="cell">9-5</div>
+      </div>
+      <div class="row" role="row">
+        <div class="cell" role="columnheader">Wed</div>
+        <div class="cell" role="cell">9-5</div>
+      </div>
+      <div class="row" role="row">
+        <div class="cell" role="columnheader">Fri</div>
+        <div class="cell" role="cell">9-5</div>
+      </div>
+      <div class="row" role="row">
+        <div class="cell" role="columnheader">Sat</div>
+        <div class="cell" role="cell">9-5</div>
+      </div>
+      <div class="row" role="row">
+        <div class="cell" role="columnheader">Sun</div>
+        <div class="cell" role="cell">9-5</div>
+      </div>
+      <div class="row" role="row">
+        <div class="cell" role="columnheader">Mon</div>
+        <div class="cell" role="cell">9-5</div>
       </div>
     </div>
 
@@ -86,6 +117,7 @@ const headerNavLinks =
 </Layout>
 
 <style>
+
   :is(h1, h2) {
     background: linear-gradient(to right, #112f4e 0%, #58b4ff 100%);
     display: inline-block;
@@ -140,10 +172,24 @@ const headerNavLinks =
     text-indent: 64px;
   }
 
-  .table {
+  [class^=table__] {
     display: flex;
     flex-flow: column nowrap;
     border: 1px solid #000;
+  }
+
+  .table__responsive{
+    display:none;
+  }
+
+  @media (width <=700px){
+    .table__desktop{
+      display: none;
+    }
+
+    .table__responsive{
+      display: block;
+    }
   }
 
   .row {
@@ -153,7 +199,7 @@ const headerNavLinks =
     }
   }
 
-  .heading {
+  [role=columnheader] {
     color: var(--gray-400);
     font-family: Corinthia, cursive;
     font-size: 14pt;

--- a/site/src/pages/museum/about.astro
+++ b/site/src/pages/museum/about.astro
@@ -79,7 +79,7 @@ const headerNavLinks =
         <div class="cell" role="cell">9-5</div>
       </div>
       <div class="row" role="row">
-        <div class="cell" role="columnheader">Mon</div>
+        <div class="cell" role="columnheader">Sun</div>
         <div class="cell" role="cell">9-5</div>
       </div>
     </div>

--- a/site/src/pages/museum/about.astro
+++ b/site/src/pages/museum/about.astro
@@ -117,7 +117,6 @@ const headerNavLinks =
 </Layout>
 
 <style>
-
   :is(h1, h2) {
     background: linear-gradient(to right, #112f4e 0%, #58b4ff 100%);
     display: inline-block;
@@ -172,22 +171,22 @@ const headerNavLinks =
     text-indent: 64px;
   }
 
-  [class^=table__] {
+  [class^="table__"] {
     display: flex;
     flex-flow: column nowrap;
     border: 1px solid #000;
   }
 
-  .table__responsive{
-    display:none;
+  .table__responsive {
+    display: none;
   }
 
-  @media (width <=700px){
-    .table__desktop{
+  @media (width <=700px) {
+    .table__desktop {
       display: none;
     }
 
-    .table__responsive{
+    .table__responsive {
       display: block;
     }
   }
@@ -199,7 +198,7 @@ const headerNavLinks =
     }
   }
 
-  [role=columnheader] {
+  [role="columnheader"] {
     color: var(--gray-400);
     font-family: Corinthia, cursive;
     font-size: 14pt;

--- a/site/src/pages/museum/about.astro
+++ b/site/src/pages/museum/about.astro
@@ -67,7 +67,7 @@ const headerNavLinks =
         <div class="cell" role="cell">9-5</div>
       </div>
       <div class="row" role="row">
-        <div class="cell" role="columnheader">Fri</div>
+        <div class="cell" role="columnheader">Thu</div>
         <div class="cell" role="cell">9-5</div>
       </div>
       <div class="row" role="row">


### PR DESCRIPTION
1. Give it the incorrect role of `grid`
2. Add `role=columnheader` attributes to heading cells in “desktop” breakpoint
3. Change layout of table in “responsive” breakpoint, but keep the `columnheader` roles, which results in incorrect announcements by screen readers
4. The times are inconsistent in the responsive version, with every day being 9-5 instead of Saturday and Sunday having extended hours.