### PR TITLE
Intentionally break skip link on blog listing page

### DIFF
--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -13,15 +13,24 @@ import { defaultNavLinks } from "@/lib/nav-links";
 type Props = ComponentProps<typeof BaseLayout> & {
   headerNavLinks?: ComponentProps<typeof Navigation>["navLinks"];
   withInsetMain?: boolean;
+  withMainId?: boolean;
 };
 
-const { headerNavLinks = defaultNavLinks, title, withInsetMain = true } = Astro.props;
+const {
+  headerNavLinks = defaultNavLinks,
+  title,
+  withInsetMain = true,
+  withMainId = true,
+} = Astro.props;
 ---
 
 <BaseLayout title={title}>
   <Header />
   <Navigation navLinks={headerNavLinks} />
-  <main id="main" class={withInsetMain ? "inset" : undefined}>
+  <main
+    id={withMainId ? "main" : undefined}
+    class={withInsetMain ? "inset" : undefined}
+  >
     <slot />
   </main>
   <Footer />

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -164,6 +164,10 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           Images zoom in on hover and do not respect prefers-reduced-motion.
         </dd>
+        <dt>2.4.1: Bypass Blocks</dt>
+        <dd>
+          The "Skip to content" link does not work properly on the blog listing page.
+        </dd>
         <dt>2.4.4 and 2.4.9: Link Purpose</dt>
         <dd>
           Each post image, as well as the arrow on the topmost post, links to its post, but has no content to describe the link.

--- a/site/src/pages/museum/blog/index.astro
+++ b/site/src/pages/museum/blog/index.astro
@@ -33,7 +33,7 @@ const postsByCategory = posts.reduce(
 );
 ---
 
-<Layout title="Blog">
+<Layout title="Blog" withMainId={false}>
   {
     livePost && (
       <div class="featured">


### PR DESCRIPTION
This implements an idea Rachael suggested recently, which is to intentionally break the skip link on one page.

This PR adds a prop to the layout which can do this on demand, and applies it to the blog listing page (not individual posts).