### PR TITLE
Fix skip link behavior and simplify its CSS

### DIFF
--- a/site/src/assets/styles/utilities.css
+++ b/site/src/assets/styles/utilities.css
@@ -15,7 +15,7 @@
   }
 }
 
-.visually-hidden {
+.visually-hidden:not(:focus):not(:active) {
   border: 0;
   clip: rect(0, 0, 0, 0);
   height: 1px;
@@ -25,9 +25,4 @@
   position: absolute;
   white-space: nowrap;
   width: 1px;
-}
-
-/* Specialization of .visually-hidden for skip navigation link */
-.skip-link:focus-visible {
-  all: revert;
 }

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -53,11 +53,15 @@ import { museumBaseUrl } from "@/lib/constants";
   }
 
   if (getMode() === "broken") {
+    let currentUrl = new URL(location.href);
     window.addEventListener("popstate", () => {
       const url = new URL(location.href);
       const query = url.searchParams.get("query") || "";
+
       if (url.pathname === `${museumBaseUrl}search/`) search(query);
-      else location.reload(); // Perform full navigation when leaving search page
+      // Perform full navigation when leaving search page, but ignore hash changes
+      else if (url.pathname !== currentUrl.pathname) location.reload();
+      currentUrl = url;
     });
 
     searchInput.addEventListener(

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -20,7 +20,7 @@ const { title } = Astro.props;
     <title>{title} - The Museum of Broken Things</title>
   </head>
   <body>
-    <a class="visually-hidden skip-link" href="#main">Skip to the main content</a>
+    <a class="visually-hidden" href="#main">Skip to the main content</a>
     <slot />
   </body>
 </html>


### PR DESCRIPTION
Fixes #47.

The cause of the issue was the `popstate` event handler hooked up for the broken version's search box. This handler was also firing on hash changes, and hitting the code path intended for leaving the search page via browser history, which has the effect of refreshing the page.

We thought the issue was only happening on Chromium derivatives, but it was actually happening even in Firefox. The difference is Firefox was somehow resilient enough to still follow the hash change, so the problem was less noticeable.

The fix is adding conditions in the event handler; while debugging this I also realized we could simplify the CSS used to make the skip link visible on focus, so that's also included in this PR.