### PR TITLE
Footer: Remove "what's wrong" link; only include small font in shop

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,11 +1,11 @@
 ---
 import { Image } from "astro:assets";
 import logo from "@/assets/images/mbt-logo.webp";
-import { getMode, type Mode } from "@/lib/mode";
+import { getMode } from "@/lib/mode";
 import { defaultNavLinks } from "@/lib/nav-links";
 
 interface Props {
-  mode?: Mode;
+  mode?: "fixed";
 }
 
 const { mode = getMode() } = Astro.props;

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -33,7 +33,7 @@ const { mode = getMode() } = Astro.props;
 
 <style>
   footer {
-    background-color: var(--black);
+    background-color: var(--gray-900);
     display: flex;
     justify-content: space-between;
     padding: 1.5rem;

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,16 +1,17 @@
 ---
 import { Image } from "astro:assets";
 import logo from "@/assets/images/mbt-logo.webp";
-
-import { slugifyPath } from "@/lib/meta";
+import { getMode, type Mode } from "@/lib/mode";
 import { defaultNavLinks } from "@/lib/nav-links";
 
-const metaAnchor = slugifyPath(
-  Astro.url.pathname.replace(import.meta.env.BASE_URL, "")
-);
+interface Props {
+  mode?: Mode;
+}
+
+const { mode = getMode() } = Astro.props;
 ---
 
-<footer>
+<footer class={mode}>
   <div class="links">
     {
       defaultNavLinks.map(({ name, href, footerClass }) => (
@@ -26,11 +27,6 @@ const metaAnchor = slugifyPath(
       The Museum of Broken Things is brought to you by Accessible Community and
       W3C, with help from <a href="https://unsplash.com/">Unsplash</a> and various
       AI chatbots.
-    </p>
-    <p>
-      <a href={`${import.meta.env.BASE_URL}#${metaAnchor}`}
-        >What's wrong with this page?</a
-      >
     </p>
   </div>
 </footer>
@@ -57,9 +53,12 @@ const metaAnchor = slugifyPath(
   }
 
   .attribution {
-    font-size: 70%;
-    min-width: 250px;
-    max-width: 250px;
+    min-width: 256px;
+    max-width: 256px;
+
+    .broken & {
+      font-size: 70%;
+    }
   }
 
   .links a {

--- a/site/src/components/meta/MetaFailureSection.astro
+++ b/site/src/components/meta/MetaFailureSection.astro
@@ -1,4 +1,6 @@
 ---
+import { slugifyPath } from '@/lib/meta';
+
 /** @fileoverview Component that handles some boilerplate for each failure section in the top page. */
 
 interface Props {
@@ -10,7 +12,7 @@ interface Props {
 const { href, title } = Astro.props;
 ---
 
-<section id={href.replace(/\//g, "-").replace(/-$/, "")}>
+<section id={slugifyPath(href)}>
   <h3><a href={`${import.meta.env.BASE_URL}${href}`}>{title}</a></h3>
   <slot />
   {

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -37,5 +37,5 @@ const {
     <slot />
   </main>
   <Toast />
-  <Footer />
+  <Footer mode="fixed" />
 </BaseLayout>

--- a/site/src/lib/meta.ts
+++ b/site/src/lib/meta.ts
@@ -1,2 +1,3 @@
+/** Converts a path to a slug for section permalinks */
 export const slugifyPath = (path: string) =>
   path.replace(/\//g, "-").replace(/^-/, "").replace(/-$/, "");


### PR DESCRIPTION
- Removes the "what's wrong" link to accommodate initial use cases for the site
  - Documents function this was using to produce slugs for URI fragments
  - Updates MetaFailureSection to use the same function (I tested the links still worked before removing them)
- Only reduce the attribution paragraph font size in gift shop pages
  - Adds `mode` parameter to Footer component, defaulting to whatever mode the site is running/built in
  - Forces `mode` to `fixed` for default museum layout
- (Added after rebase over #52) Explicitly set footer background to gray-900 (darker than black variable) to make gold stand out more