### PR TITLE
Only break search on museum home page

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,10 +1,17 @@
 ---
 import { Image } from "astro:assets";
+import type { ComponentProps } from "astro/types";
 import { museumBaseUrl } from "@/lib/constants";
 import Search from "./Search.astro";
 import UserControls from "./UserControls.astro";
 
 import logo from "@/assets/images/mbt-logo.webp";
+
+interface Props {
+  searchMode?: ComponentProps<typeof Search>["mode"];
+}
+
+const { searchMode } = Astro.props;
 ---
 
 <header>
@@ -19,7 +26,7 @@ import logo from "@/assets/images/mbt-logo.webp";
     <div>Museum of Broken Things</div>
   </div>
   <div>
-    <Search />
+    <Search mode={searchMode} />
     <UserControls />
   </div>
 </header>

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -1,25 +1,36 @@
 ---
 import { Icon } from "astro-icon/components";
-import FixableRegion from "./FixableRegion.astro";
 import { museumBaseUrl } from "@/lib/constants";
+import { getMode } from "@/lib/mode";
+
+interface Props {
+  mode?: "fixed";
+}
+
+const { mode = getMode() } = Astro.props;
 ---
 
-<FixableRegion>
-  <input id="search" placeholder="Search" />
-  <form slot="fixed" role="search" action={`${museumBaseUrl}search/`}>
-    <label
-      >Search
-      <input id="search" type="search" name="query" />
-    </label>
-    <button class="outline"><Icon name="ri:search-line" /></button>
-  </form>
-</FixableRegion>
+{
+  mode === "broken" ? (
+    <input id="search" placeholder="Search" />
+  ) : (
+    <form slot="fixed" role="search" action={`${museumBaseUrl}search/`}>
+      <label>
+        Search
+        <input id="search" type="search" name="query" />
+      </label>
+      <button class="outline">
+        <Icon name="ri:search-line" />
+        <span class="visually-hidden">Search</span>
+      </button>
+    </form>
+  )
+}
 
 <script>
   import debounce from "lodash-es/debounce";
   import type { SearchResult } from "@/pages/museum/api/search";
   import { museumBaseUrl } from "@/lib/constants";
-  import { getMode } from "@/lib/mode";
   import { fetchApi } from "@/lib/client/fetch";
 
   const response = await fetchApi(`${museumBaseUrl}api/search/`);
@@ -52,7 +63,9 @@ import { museumBaseUrl } from "@/lib/constants";
     search(query);
   }
 
-  if (getMode() === "broken") {
+  // Feature-detect broken state, since it's parameterized at build time
+  const isBroken = !document.querySelector("form[role='search']");
+  if (isBroken) {
     let currentUrl = new URL(location.href);
     window.addEventListener("popstate", () => {
       const url = new URL(location.href);
@@ -99,6 +112,7 @@ import { museumBaseUrl } from "@/lib/constants";
   }
 
   input {
-    padding: 0.45em;
+    padding: 0.45rem;
+    width: 10rem;
   }
 </style>

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -12,6 +12,7 @@ import { defaultNavLinks } from "@/lib/nav-links";
 
 type Props = ComponentProps<typeof BaseLayout> & {
   headerNavLinks?: ComponentProps<typeof Navigation>["navLinks"];
+  withFixedSearch?: boolean;
   withInsetMain?: boolean;
   withMainId?: boolean;
 };
@@ -19,13 +20,14 @@ type Props = ComponentProps<typeof BaseLayout> & {
 const {
   headerNavLinks = defaultNavLinks,
   title,
+  withFixedSearch = true,
   withInsetMain = true,
   withMainId = true,
 } = Astro.props;
 ---
 
 <BaseLayout title={title}>
-  <Header />
+  <Header searchMode={withFixedSearch ? "fixed" : undefined} />
   <Navigation navLinks={headerNavLinks} />
   <main
     id={withMainId ? "main" : undefined}

--- a/site/src/pages/museum/index.astro
+++ b/site/src/pages/museum/index.astro
@@ -25,7 +25,7 @@ const carouselEntries = [
 ]
 ---
 
-<Layout title="Home">
+<Layout title="Home" withFixedSearch={false}>
   <div class="outset">
     <Carousel entries={carouselEntries} />
   </div>


### PR DESCRIPTION
This adds plumbing to the Search, Header, and Layout components to be able to override whether the broken or fixed version of the Search component is used, defaulting to the overall mode the site is being run/built in and only being overridable to fixed (i.e. you can't break it in fixed mode).

I also fixed the submit button in the fixed version, which I realized I hadn't included any sort of text label in.

This PR does not include any update to the top-level index page, since the search failures are already documented in the Home & Search section.