### PR TITLE
Duplicate entry links in sports collection page

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -255,6 +255,23 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       </dl>
     </MetaFailureSection>
 
+    <MetaFailureSection href="museum/collections/sports/" title="Sports Collection">
+      <dl slot="wcag2">
+        <dt>1.1.1: Non-text Content</dt>
+        <dd>
+          The alt text on each entry's image repeats the entry's title, rather than
+          describing the image.
+        </dd>
+      </dl>
+
+      <dl slot="wcag3">
+        <dt>Interface Verbosity</dt>
+        <dd>
+          Each entry effectively has two separate links with identical labels.
+        </dd>
+      </dl>
+    </MetaFailureSection>
+
     <MetaFailureSection href="museum/collections/technology/" title="Technology Collection">
       <p>This section includes the technology collection page and related item subpages.</p>
 

--- a/site/src/pages/museum/collections/[category]/index.astro
+++ b/site/src/pages/museum/collections/[category]/index.astro
@@ -32,7 +32,10 @@ export async function getStaticPaths() {
 const { category, exhibits } = Astro.props;
 const { Content } = await category.render();
 
-const shouldWrapImageInLink = getMode() === "broken" && category.slug === "music";
+const shouldWrapImageInLink =
+  getMode() === "broken" && category.slug === "music";
+const shouldDuplicateLink =
+  getMode() === "broken" && category.slug === "sports";
 ---
 
 <Layout title={category.data.title}>
@@ -80,13 +83,23 @@ const shouldWrapImageInLink = getMode() === "broken" && category.slug === "music
             href={`../${slug}/`}
           >
             <div class="image-container">
-              <CoverImage
-                src={data.image}
-                alt={data.skipAlt ? null : data.imageDescription}
-                objectPosition={data.imagePosition}
-                height="200"
-                widths={[960]}
-              />
+              <ConditionalParent
+                as="a"
+                if={shouldDuplicateLink}
+                href={`../${slug}/`}
+              >
+                <CoverImage
+                  src={data.image}
+                  alt={
+                    data.skipAlt
+                      ? null
+                      : data[shouldDuplicateLink ? "title" : "imageDescription"]
+                  }
+                  objectPosition={data.imagePosition}
+                  height="200"
+                  widths={[960]}
+                />
+              </ConditionalParent>
             </div>
             <div class="content">
               <ConditionalParent


### PR DESCRIPTION
This is effectively a variation on #40 for a different collection. This wraps each entry's image in a separate link, and sets the image's alt text to the same content as the text label, resulting in duplicate links for each entry.

I made an attempt at updating the top-level index with things I think this would fail, but I'm a bit up in the air on whether there's a better fit, especially for WCAG 2.