### PR TITLE
Implement fly-out nav menu with 3 variants

### DIFF
--- a/site/src/components/Carousel.astro
+++ b/site/src/components/Carousel.astro
@@ -91,13 +91,15 @@ const collectionLabels = {
     position: absolute;
     inset: 0;
     text-align: center;
+    /* Use negative z-index to avoid interfering with e.g. nav menu */
+    z-index: -2;
 
     &.in {
-      z-index: 2;
+      z-index: 0;
     }
 
     &.out {
-      z-index: 1;
+      z-index: -1;
     }
 
     &::before {

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,20 +1,31 @@
 ---
 import { Image } from "astro:assets";
 import logo from "@/assets/images/mbt-logo.webp";
+
 import { getMode } from "@/lib/mode";
-import { defaultNavLinks } from "@/lib/nav-links";
+import { defaultNavLinks, type NavLink } from "@/lib/nav-links";
 
 interface Props {
   mode?: "fixed";
 }
 
 const { mode = getMode() } = Astro.props;
+
+const flattenedNavLinks = defaultNavLinks.reduce((links, parentOrLink) => {
+  if ("children" in parentOrLink)
+    parentOrLink.children.forEach((link) => {
+      // Flatten children, but skip individual collection pages
+      if (!/collections\/.+/.test(link.href)) links.push(link);
+    })
+  else links.push(parentOrLink);
+  return links;
+}, [] as NavLink[]);
 ---
 
 <footer class={mode}>
   <div class="links">
     {
-      defaultNavLinks.map(({ name, href, footerClass }) => (
+      flattenedNavLinks.map(({ name, href, footerClass }) => (
         <a class={footerClass} {href}>
           {name}
         </a>

--- a/site/src/components/Navigation.astro
+++ b/site/src/components/Navigation.astro
@@ -1,50 +1,175 @@
 ---
-import { defaultNavLinks, type NavLink } from "@/lib/nav-links";
+import { Icon } from "astro-icon/components";
+import { getMode } from "@/lib/mode";
+import { defaultNavLinks, type NavTree } from "@/lib/nav-links";
+import ConditionalParent from "./ConditionalParent.astro";
 
 interface Props {
-  navLinks?: NavLink[]
+  /**
+   * Indicates behavior in broken mode: open-on-focus or open-on-hover.
+   * If unspecified, uses expand/collapse behavior.
+   */
+  failureMode?: "focus" | "hover";
+  /** Links to display in nav. Supports one level of nesting. */
+  navLinks?: NavTree;
 }
 
-const { navLinks = defaultNavLinks } = Astro.props;
+const { failureMode, navLinks = defaultNavLinks } = Astro.props;
+const actualFailureMode = getMode() === "broken" ? failureMode : undefined;
 ---
 
-<nav aria-label="Site">
+<nav aria-label="Site" data-failure-mode={actualFailureMode}>
   <ul>
     {
-      navLinks.map(({ name, href, headerClass }) => (
-        <li class={headerClass}>
-          <a {href}>{name}</a>
-        </li>
-      ))
+      navLinks.map(({ name, ...rest }) =>
+        "children" in rest ? (
+          <li tabindex={actualFailureMode === "focus" ? 0 : undefined}>
+            <ConditionalParent
+              as="button"
+              if={!actualFailureMode}
+              aria-controls={`nav-${name.toLowerCase()}`}
+              aria-expanded="false"
+            >
+              {name}
+              {!actualFailureMode && <Icon name="ri:arrow-down-s-line" />}
+            </ConditionalParent>
+            <ul
+              id={actualFailureMode ? undefined : `nav-${name.toLowerCase()}`}
+            >
+              {rest.children.map(({ headerClass, href, name }) => (
+                <li class={headerClass}>
+                  <a {href}>{name}</a>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ) : (
+          <li class={rest.headerClass}>
+            <a href={rest.href}>{name}</a>
+          </li>
+        )
+      )
     }
   </ul>
   <slot />
 </nav>
 
+<script>
+  const navEl = document.querySelector("nav[aria-label='Site']") as HTMLElement;
+  const failureMode = navEl.dataset.failureMode;
+  if (!failureMode) {
+    navEl.addEventListener("click", (event) => {
+      const el = event.target as HTMLElement;
+      if (!el.hasAttribute("aria-expanded")) return;
+      const isExpanded = el.getAttribute("aria-expanded") === "true";
+
+      if (!isExpanded) {
+        // Close any other expanded submenus before opening a new one
+        navEl.querySelectorAll("[aria-expanded='true']").forEach((el) => {
+          el.setAttribute("aria-expanded", "false");
+        });
+      }
+      el.setAttribute("aria-expanded", "" + !isExpanded);
+      event.preventDefault();
+    });
+
+    navEl.addEventListener("keydown", (event) => {
+      const el = event.target as HTMLElement;
+      if (event.key === "Escape") {
+        const buttonEl = el.closest("nav > ul > li")?.querySelector("button");
+        if (!buttonEl?.hasAttribute("aria-expanded")) return;
+        buttonEl.setAttribute("aria-expanded", "false");
+        (buttonEl as HTMLElement).focus();
+        event.preventDefault();
+      }
+      // Enter/space are already handled by click handler (for buttons)
+    });
+
+    navEl.addEventListener("focusout", (event) => {
+      const el = event.target as HTMLElement;
+      const relatedEl = event.relatedTarget as HTMLElement | null;
+      const parentItemEl = el.closest("nav > ul > li");
+      // Collapse submenu if user tabs out of it
+      if (parentItemEl && parentItemEl !== relatedEl?.closest("nav > ul > li"))
+        parentItemEl.querySelector("button")?.setAttribute("aria-expanded", "false");
+    });
+  }
+</script>
+
 <style is:global>
   /* Apply styles globally to also encompass any links in the end slot */
-  nav[aria-label='Site'] {
+  nav[aria-label="Site"] {
     background: var(--black);
     display: flex;
     justify-content: space-between;
     padding: 0 1rem;
+    position: relative;
 
     & ul {
       display: flex;
-      gap: 1em;
       list-style: none;
       margin: 0;
       padding: 0;
     }
-    & a {
+
+    /* Top-level-specific */
+    & > ul {
+      gap: 1em;
+      z-index: 1; /* Prevent any stacking context below nav from covering focus outlines */
+
+      & > li {
+        position: relative;
+
+        /* Submenu-specific */
+        & > ul {
+          background: var(--black);
+          flex-direction: column;
+          position: absolute;
+          left: 0;
+          top: 100%;
+          z-index: 1;
+        }
+
+        & button {
+          background: none !important; /* Override all states */
+        }
+
+        & svg {
+          /* Make icons ignore clicks for easier handler logic */
+          pointer-events: none;
+        }
+      }
+    }
+
+    & a,
+    & button,
+    &[data-failure-mode] li:not(:has(> a, button)) {
       color: var(--gray-050);
+      cursor: pointer; /* For consistency across all modes */
       display: block;
       padding: 0.5em;
-      text-decoration: none;
       white-space: nowrap;
+    }
+
+    & a {
+      text-decoration: none;
       &:hover {
         text-decoration: underline;
       }
+    }
+
+    /* Collapsed/expanded styles */
+
+    &[data-failure-mode="hover"] > ul > li:not(:hover) > ul,
+    &[data-failure-mode="focus"] > ul > li:not(:focus-within) > ul,
+    &:not([data-failure-mode]) > ul > li:has([aria-expanded="false"]) > ul {
+      display: none;
+    }
+
+    &[data-failure-mode="hover"] li:hover svg,
+    &[data-failure-mode="focus"] li:focus-within svg,
+    &:not([data-failure-mode]) li:has([aria-expanded="true"]) svg {
+      transform: rotate(180deg);
     }
   }
 </style>

--- a/site/src/components/Navigation.astro
+++ b/site/src/components/Navigation.astro
@@ -132,6 +132,8 @@ const actualFailureMode = getMode() === "broken" ? failureMode : undefined;
 
         & button {
           background: none !important; /* Override all states */
+          position: relative; /* Force context for z-index */
+          z-index: 2; /* Avoid submenu obscuring parent item's focus outline */
         }
 
         & svg {

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -12,6 +12,7 @@ import { defaultNavLinks } from "@/lib/nav-links";
 import BaseLayout from "./BaseLayout.astro";
 
 type Props = ComponentProps<typeof BaseLayout> & {
+  headerNavFailureMode?: ComponentProps<typeof Navigation>["failureMode"];
   headerNavLinks?: ComponentProps<typeof Navigation>["navLinks"];
   withFixedSearch?: boolean;
   withInsetMain?: boolean;
@@ -19,6 +20,7 @@ type Props = ComponentProps<typeof BaseLayout> & {
 };
 
 const {
+  headerNavFailureMode,
   headerNavLinks = defaultNavLinks,
   title,
   withFixedSearch = true,
@@ -29,7 +31,7 @@ const {
 
 <BaseLayout title={title}>
   <Header searchMode={withFixedSearch ? "fixed" : undefined} />
-  <Navigation navLinks={headerNavLinks} />
+  <Navigation failureMode={headerNavFailureMode} navLinks={headerNavLinks} />
   <main
     id={withMainId ? "main" : undefined}
     class={withInsetMain ? "inset" : undefined}

--- a/site/src/layouts/ShopLayout.astro
+++ b/site/src/layouts/ShopLayout.astro
@@ -24,7 +24,7 @@ const headerNavLinks = [
 
 <BaseLayout title={title}>
   <Header />
-  <Navigation navLinks={headerNavLinks}>
+  <Navigation failureMode="hover" navLinks={headerNavLinks}>
     <a href={`${museumBaseUrl}gift-shop/checkout/`}>
       <span id="cart-empty"><Icon name="ri:shopping-cart-line" /></span>
       <span id="cart-filled" hidden><Icon name="ri:shopping-cart-fill" /></span>

--- a/site/src/lib/nav-links.ts
+++ b/site/src/lib/nav-links.ts
@@ -52,6 +52,10 @@ for (const entry of defaultNavLinks) {
   else prependHref(entry);
 }
 
+/** Utility function to distinguish NavLink from NavParent and inform typings */
+export const checkIsNavLink = (entry: NavLink | NavParent): entry is NavLink =>
+  "href" in entry;
+
 /** Utility function to recursively filter links (not parents) in a NavTree structure. */
 export const filterNavTreeLinks = (
   navTree: NavTree,

--- a/site/src/lib/nav-links.ts
+++ b/site/src/lib/nav-links.ts
@@ -7,15 +7,63 @@ export interface NavLink {
   name: string;
 }
 
-export const defaultNavLinks: NavLink[] = [
-  { href: "collections/", name: "Collections" },
-  { href: "tour/", name: "Take a Tour" },
+interface NavParent {
+  children: NavLink[];
+  name: string;
+}
+
+export type NavTree = Array<NavLink | NavParent>;
+
+export const defaultNavLinks: NavTree = [
+  {
+    name: "Collections",
+    children: [
+      { href: "collections/dishes/", name: "Dishes" },
+      { href: "collections/music/", name: "Music" },
+      { href: "collections/sports/", name: "Sports" },
+      { href: "collections/technology/", name: "Technology" },
+      { href: "collections/", name: "All Collections" },
+    ],
+  },
   { href: "blog/", name: "Blog", headerClass: "hidden-below-lg" },
-  { href: "gift-shop/", name: "Gift Shop", headerClass: "hidden-below-lg", footerClass: "hidden-below-lg" },
-  { href: "map/", name: "Museum Map" },
+  {
+    href: "gift-shop/",
+    name: "Gift Shop",
+    headerClass: "hidden-below-lg",
+    footerClass: "hidden-below-lg",
+  },
+  {
+    name: "Visit",
+    children: [
+      { href: "map/", name: "Museum Map" },
+      { href: "tour/", name: "Take a Tour" },
+    ],
+  },
   { href: "volunteer/", name: "Volunteer" },
   { href: "about/", name: "About" },
-].map(({href, ...rest}) => ({
-  href: `${museumBaseUrl}${href}`,
-  ...rest
-}));
+];
+
+function prependHref(navLink: NavLink) {
+  navLink.href = `${museumBaseUrl}${navLink.href}`;
+}
+
+for (const entry of defaultNavLinks) {
+  if ("children" in entry) entry.children.forEach(prependHref);
+  else prependHref(entry);
+}
+
+/** Utility function to recursively filter links (not parents) in a NavTree structure. */
+export const filterNavTreeLinks = (
+  navTree: NavTree,
+  fn: (entry: NavLink) => boolean
+) =>
+  navTree
+    .filter((entry) => ("children" in entry ? true : fn(entry)))
+    .map((entry) =>
+      "children" in entry
+        ? {
+            ...entry,
+            children: entry.children.filter(fn),
+          }
+        : entry
+    );

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -497,6 +497,14 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           Nothing is disclosed up-front about the information that will be required to complete checkout.
         </dd>
+        <dt>Keyboard Only</dt>
+        <dd>
+          In the top navigation bar, parent items are not focusable (and therefore not openable) via keyboard.
+        </dd>
+        <dt>Name, Role, Value, State</dt>
+        <dd>
+          In the top navigation bar, there is no programmatic indication of expandable items.
+        </dd>
         <dt>Numbered steps</dt>
         <dd>
           Checkout steps are not numbered; progress through the process is not indicated at all.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -360,6 +360,10 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           The "Blog" heading is superimposed over an image with no overlay to guarantee minimum contrast.
         </dd>
+        <dt>1.4.13: Content on Hover or Focus</dt>
+        <dd>
+          In the top navigation bar, nested items open on keyboard focus and can only be dismissed by moving focus.
+        </dd>
         <dt>2.3.3: Animation from Interactions</dt>
         <dd>
           Images zoom in on hover and do not respect prefers-reduced-motion.
@@ -380,6 +384,10 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           The first post under "In the News" leads to a 404 page with no clear description of what went wrong.
         </dd>
+        <dt>4.1.2: Name, Role, Value</dt>
+        <dd>
+          In the top navigation bar, there is no programmatic indication of expandable items.
+        </dd>
       </dl>
     </MetaFailureSection>
 
@@ -393,6 +401,14 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       <dl slot="wcag2">
         <dt>1.4.3 and 1.4.6: Contrast</dt>
         <dd>Text is superimposed over images with no overlay to guarantee minimum contrast.</dd>
+        <dt>1.4.13: Content on Hover or Focus</dt>
+        <dd>
+          In the top navigation bar, nested items open on hover and can only be dismissed by moving the pointer.
+        </dd>
+        <dt>2.1.1: Keyboard</dt>
+        <dd>
+          In the top navigation bar, parent items are not focusable (and therefore not openable) via keyboard.
+        </dd>
         <dt>2.2.3: No Timing</dt>
         <dd>
           Forms in the checkout process time out after an undisclosed period of time.
@@ -422,7 +438,11 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           The quantity field uses <code>type="tel"</code>, which allows non-numeric input,
           rather than the more appropriate <code>type="number"</code>.
-        </dd> 
+        </dd>
+        <dt>4.1.2: Name, Role, Value</dt>
+        <dd>
+          In the top navigation bar, there is no programmatic indication of expandable items.
+        </dd>
       </dl>
 
       <dl slot="wcag3">

--- a/site/src/pages/museum/blog/[category]/[post].astro
+++ b/site/src/pages/museum/blog/[category]/[post].astro
@@ -25,7 +25,7 @@ const { Content } = await post.render();
 const dateFormat = new Intl.DateTimeFormat(["en-GB"], { dateStyle: "medium" });
 ---
 
-<Layout title={post.data.title} withInsetMain={false}>
+<Layout headerNavFailureMode="focus" title={post.data.title} withInsetMain={false}>
   <article>
     <div
       class="background outset"

--- a/site/src/pages/museum/blog/index.astro
+++ b/site/src/pages/museum/blog/index.astro
@@ -33,7 +33,7 @@ const postsByCategory = posts.reduce(
 );
 ---
 
-<Layout title="Blog" withMainId={false}>
+<Layout headerNavFailureMode="focus" title="Blog" withMainId={false}>
   {
     livePost && (
       <div class="featured">

--- a/site/src/pages/museum/collections/index.astro
+++ b/site/src/pages/museum/collections/index.astro
@@ -5,6 +5,7 @@ import Fixable from "@/components/Fixable.astro";
 import Layout from "@/layouts/Layout.astro";
 import { getDownsizedSrc } from "@/lib/image";
 import {
+  checkIsNavLink,
   defaultNavLinks,
   filterNavTreeLinks,
   type NavLink,
@@ -40,9 +41,9 @@ for (const { data, slug } of exhibits) {
 const tabIndices = [1, 2, 4, 6, 3, 5, 7];
 
 const seeMoreLabels = ["Blog", "Gift Shop"];
-const seeMoreLinks = defaultNavLinks.filter(
-  (link): link is NavLink => "href" in link && seeMoreLabels.includes(link.name)
-);
+const seeMoreLinks = defaultNavLinks
+  .filter((link) => seeMoreLabels.includes(link.name))
+  .filter(checkIsNavLink);
 const headerNavLinks = filterNavTreeLinks(
   defaultNavLinks,
   ({ name }) => !seeMoreLabels.includes(name)

--- a/site/src/pages/museum/collections/index.astro
+++ b/site/src/pages/museum/collections/index.astro
@@ -4,7 +4,11 @@ import { sortBy, uniqBy } from "lodash-es";
 import Fixable from "@/components/Fixable.astro";
 import Layout from "@/layouts/Layout.astro";
 import { getDownsizedSrc } from "@/lib/image";
-import { defaultNavLinks } from "@/lib/nav-links";
+import {
+  defaultNavLinks,
+  filterNavTreeLinks,
+  type NavLink,
+} from "@/lib/nav-links";
 
 const categories = sortBy(
   (await getCollection("exhibit-categories")).filter(
@@ -36,10 +40,11 @@ for (const { data, slug } of exhibits) {
 const tabIndices = [1, 2, 4, 6, 3, 5, 7];
 
 const seeMoreLabels = ["Blog", "Gift Shop"];
-const seeMoreLinks = defaultNavLinks.filter(({ name }) =>
-  seeMoreLabels.includes(name)
+const seeMoreLinks = defaultNavLinks.filter(
+  (link): link is NavLink => "href" in link && seeMoreLabels.includes(link.name)
 );
-const headerNavLinks = defaultNavLinks.filter(
+const headerNavLinks = filterNavTreeLinks(
+  defaultNavLinks,
   ({ name }) => !seeMoreLabels.includes(name)
 );
 ---

--- a/site/src/pages/museum/tour.astro
+++ b/site/src/pages/museum/tour.astro
@@ -1,11 +1,11 @@
 ---
 import Layout from "@/layouts/Layout.astro";
 import { getMode } from "@/lib/mode";
-import { defaultNavLinks } from "@/lib/nav-links";
+import { defaultNavLinks, filterNavTreeLinks } from "@/lib/nav-links";
 
 const headerNavLinks =
   getMode() === "broken"
-    ? defaultNavLinks.filter(({ name }) => name !== "Take a Tour")
+    ? filterNavTreeLinks(defaultNavLinks, ({ name }) => name !== "Take a Tour")
     : defaultNavLinks;
 ---
 


### PR DESCRIPTION
This reorganizes the nav to include 2 submenus:
  - Collections (lists some specific collections + an "all collections" link that goes to where the Collections nav item went before)
  - Visit (includes Museum Map and Take a Tour

On most pages, submenus use a button for their top-level entry which includes `aria-controls` pointing to the submenu list, and `aria-expanded` which the CSS uses to control visibility. Submenus close upon losing focus or upon escape keypress.

The following pages are intentionally broken (when not run in fixed mode):

- On gift shop pages: submenus trigger specifically on hover and are completely inaccessible via keyboard
- On blog pages: submenus trigger specifically on focus, and focus needs to be moved in order to close them

## Changes

- `nav-links.ts`: Nav list is restructured into parent/child structure; added a function for filtering leaf nodes
- Navigation: Updates to use new nav structure; conditional rendering and additional JS for fixed mode; CSS for fixed and failure modes
- Carousel component: Tweaked z-index values to avoid obscuring nav submenus
- Footer, ShopLayout, collections index, tour page: Updates to account for new nav data structure
- Layout, ShopLayout, blog pages: Updates to set nav failure mode