### PR TITLE
Add cookie banner at bottom of home page

### DIFF
--- a/site/src/components/CookieBanner.astro
+++ b/site/src/components/CookieBanner.astro
@@ -56,7 +56,7 @@ const isBroken = getMode() === "broken";
     border-top-right-radius: 16px;
     box-shadow: 0 0 8px rgba(0, 0, 0, 0.4);
     max-width: 65ch;
-    padding: 0 calc(1rem * var(--ms5)) 1rem;
+    padding: 1rem calc(1rem * var(--ms5)) 0;
     position: fixed;
     bottom: 0;
     left: 0;
@@ -69,6 +69,10 @@ const isBroken = getMode() === "broken";
     gap: calc(1rem * var(--ms5));
   }
 
+  h2 {
+    margin: 0;
+  }
+
   button {
     width: 10rem;
   }
@@ -77,5 +81,32 @@ const isBroken = getMode() === "broken";
     display: flex;
     flex-direction: column;
     gap: 1rem;
+  }
+</style>
+
+<style is:global>
+  /* Styles for passing 2.4.11 ([open] only ever matches in fixed mode) */
+  html,
+  body {
+    &:has(#cookie-banner[open]) {
+      scroll-padding-bottom: 22rem;
+    }
+  }
+
+  body footer:has(~ #cookie-banner[open]) {
+    padding-bottom: 22rem;
+  }
+
+  @media (min-width: 30rem) {
+    html,
+    body {
+      &:has(#cookie-banner[open]) {
+        scroll-padding-bottom: 16rem;
+      }
+    }
+
+    body footer:has(~ #cookie-banner[open]) {
+      padding-bottom: 16rem;
+    }
   }
 </style>

--- a/site/src/components/CookieBanner.astro
+++ b/site/src/components/CookieBanner.astro
@@ -1,0 +1,81 @@
+---
+import { getMode } from "@/lib/mode";
+import ConditionalParent from "./ConditionalParent.astro";
+import Fixable from "./Fixable.astro";
+
+const isBroken = getMode() === "broken";
+---
+
+<ConditionalParent as="div" if={isBroken} id="cookie-banner" hidden>
+  <ConditionalParent as="dialog" if={!isBroken} id="cookie-banner">
+    <h2>We use cookies to personalize your experience.</h2>
+    <div class="container">
+      <div>
+        <p>
+          We store cookies on your device because they are delicious. If you are
+          fine with us doing whatever we want, click <strong>Accept All</strong
+          >.
+        </p>
+        <p>
+          We recognize that some visitors value privacy above extra
+          functionality. To lose out on some features instead, click <strong
+            >Reject All</strong
+          >.
+        </p>
+      </div>
+      <Fixable as="form" action="#" fixed={{ method: "dialog" }}>
+        <button>Accept All</button>
+        <button>Reject All</button>
+      </Fixable>
+    </div>
+  </ConditionalParent>
+</ConditionalParent>
+
+<script>
+  import { persist, recall } from "@/lib/client/store";
+
+  const el = document.getElementById("cookie-banner")!;
+
+  if (!recall("hasDismissedCookieBanner")) {
+    if (el.tagName === "DIALOG") (el as HTMLDialogElement).show();
+    else el.hidden = false;
+  }
+
+  el.querySelector("form")!.addEventListener("submit", (event) => {
+    if (el.tagName !== "DIALOG") {
+      event.preventDefault();
+      el.hidden = true;
+    }
+    persist("hasDismissedCookieBanner", true);
+  });
+</script>
+
+<style>
+  #cookie-banner {
+    background-color: var(--white);
+    border-top-right-radius: 16px;
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.4);
+    max-width: 65ch;
+    padding: 0 calc(1rem * var(--ms5)) 1rem;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    z-index: 9999;
+  }
+
+  .container {
+    display: flex;
+    align-items: center;
+    gap: calc(1rem * var(--ms5));
+  }
+
+  button {
+    width: 10rem;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/site/src/components/CookieBanner.astro
+++ b/site/src/components/CookieBanner.astro
@@ -48,6 +48,9 @@ const isBroken = getMode() === "broken";
     }
     persist("hasDismissedCookieBanner", true);
   });
+
+  // Ensure scroll begins at top (e.g. when zoomed to 400%) in fixed version
+  el.scrollTop = 0;
 </script>
 
 <style>
@@ -61,12 +64,24 @@ const isBroken = getMode() === "broken";
     bottom: 0;
     left: 0;
     z-index: 9999;
+
+    dialog& {
+      max-height: 100vh;
+      overflow: auto;
+    }
   }
 
   .container {
     display: flex;
     align-items: center;
+    flex-direction: column;
     gap: calc(1rem * var(--ms5));
+  }
+
+  @media (min-width: 30em) {
+    .container {
+      flex-direction: row;
+    }
   }
 
   h2 {

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -36,8 +36,7 @@ const flattenedNavLinks = defaultNavLinks.reduce((links, parentOrLink) => {
     <Image src={logo} alt="Museum of Broken Things" width="256" height="256" />
     <p class="attribution">
       The Museum of Broken Things is brought to you by Accessible Community and
-      W3C, with help from <a href="https://unsplash.com/">Unsplash</a> and various
-      AI chatbots.
+      W3C, with help from Unsplash and various AI chatbots.
     </p>
   </div>
 </footer>

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -40,4 +40,5 @@ const {
   </main>
   <Toast />
   <Footer mode="fixed" />
+  <slot name="end" />
 </BaseLayout>

--- a/site/src/lib/client/store.ts
+++ b/site/src/lib/client/store.ts
@@ -20,6 +20,7 @@ export const storeSchema = z.object({
     )
     .default({}),
   favorites: z.record(z.string(), z.boolean()).default({}),
+  hasDismissedCookieBanner: z.boolean().default(false),
   loggedInAt: z.string().datetime().nullable().default(null),
   registration: z.object({
     email: z.string().email(),

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -13,7 +13,12 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
     </p>
     <p>This page summarizes the accessibility issues from WCAG 2 and WCAG 3 for each section of the site. 
     <p>
-      <strong>Reminder:</strong> This site is an example only. The contents are made up and it does not perform real sign-in or payment processing. Do not enter real information!
+      <strong>Reminder:</strong> This site is an example only.
+      The contents are made up and it does not perform real sign-in or payment processing.
+      Do not enter real information!
+    </p>
+    <p>
+      (The site also does not actually store cookies, despite what the home page might suggest.)
     </p>
   </section>
 
@@ -57,7 +62,12 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dt>2.4.9 Link Purpose (Link Only)</dt>
         <dd>
           The Read More and Explore link text does not provide enough information to know which links go where.
-        </dd>   
+        </dd>
+        <dt>2.4.11 and 2.4.12: Focus not Obscured</dt>
+        <dd>
+          The cookie notice at the bottom-left of the page fully obscures some of the footer links,
+          which occur before it in the document's focus order.
+        </dd>
         <dt>3.2.2: On Input</dt>
         <dd>
           The search box automatically performs the search and changes to

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -53,6 +53,10 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           The scrim on the carousel is not always enough to guarantee sufficient contrast.
         </dd>
+        <dt>1.4.10: Reflow</dt>
+        <dd>
+          At 400% zoom, the cookie notice occupies more than the full screen and cannot be scrolled.
+        </dd>
         <dt>2.2.2: Pause, Stop, Hide</dt>
         <dd>
           The carousel does not include controls to stop moving and updating.

--- a/site/src/pages/museum/index.astro
+++ b/site/src/pages/museum/index.astro
@@ -1,8 +1,9 @@
 ---
 import { getCollection, getEntry } from "astro:content";
+import Carousel from "@/components/Carousel.astro";
+import CookieBanner from "@/components/CookieBanner.astro";
 import CoverImage from "@/components/CoverImage.astro";
 import Layout from "@/layouts/Layout.astro";
-import Carousel from "@/components/Carousel.astro";
 
 const featuredCategories = (await getCollection("exhibit-categories")).filter(
   ({ data }) => !!data.topDescription && !!data.topImageItem
@@ -63,6 +64,7 @@ const carouselEntries = [
   <div class="cards-footer">
     <a href="collections/">Our collections &rArr;</a>
   </div>
+  <CookieBanner slot="end" />
 </Layout>
 
 <style>


### PR DESCRIPTION
This fails both Focus not Obscured criteria by placing a cookie banner at the bottom left of the home page in a way that should be guaranteed to cover one or more of the links in the footer. The banner is intentionally placed after the footer in the document order to attempt to highlight the issue.

The banner dismisses upon clicking either button, and will not be shown again (unless you clear localStorage).

(Regardless of what the banner says, the code in this repo never stores cookies.)

Note: This PR removes the link around "Unsplash" in the footer to avoid needing to work around it in the fixed version.