### PR TITLE
Add workflow to run check on PRs

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,0 +1,24 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+          node-version: 20
+      - name: Install dependencies
+        working-directory: site
+        run: npm ci
+      - name: Check (TypeScript)
+        working-directory: site
+        run: npm run check


### PR DESCRIPTION
This runs `npm run check` on PRs, to ensure that we don't accidentally merge something with errors that can be caught at build time.

(This does not run the full build, since typically the `check` step is what will fail, and the full build takes close to a full minute on github, primarily due to optimizing images.)

- [Example failed run](https://github.com/kfranqueiro/fixable/actions/runs/10818896170/job/30015538034?pr=1)
- [Example successful run](https://github.com/kfranqueiro/fixable/actions/runs/10818908992/job/30015581323?pr=1)