### PR TITLE
Map: customize focus outline on buttons to fail 2.4.13

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -506,6 +506,11 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
           Single-character key bindings are implemented across the entire page
           for map movement, and cannot be turned off or customized.
         </dd>
+        <dt>2.4.13: Focus Appearance</dt>
+        <dd>
+          The map controls use a dotted focus outline with a color that falls well below
+          3:1 contrast against the underlying map.
+        </dd>
         <dt>2.5.1: Pointer Gestures</dt>
         <dd>
           On mobile viewports, the only way to zoom the map is via a pinch gesture.

--- a/site/src/pages/museum/map.astro
+++ b/site/src/pages/museum/map.astro
@@ -273,6 +273,10 @@ import Layout from "@/layouts/Layout.astro";
       position: absolute;
       right: 0;
 
+      &:focus {
+        outline: 2px dotted var(--gold-vivid-200);
+      }
+
       & svg {
         height: var(--button-size);
         width: var(--button-size);


### PR DESCRIPTION
This adds a gold dotted outline that falls well below 3:1 contrast against the map (even below 2:1).