### PR TITLE
Header/nav and responsive adjustments

### DIFF
--- a/site/src/assets/styles/button.css
+++ b/site/src/assets/styles/button.css
@@ -9,6 +9,7 @@ a.button-outline {
   padding: 0.5rem;
   text-align: center;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 button:not([class]),

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -15,17 +15,11 @@ const { searchMode } = Astro.props;
 ---
 
 <header>
-  <div class="logo">
-    <a href={museumBaseUrl}><Image
-        src={logo}
-        alt="Museum of Broken Things"
-        width="80"
-        height="80"
-      />
-    </a>
-    <div>Museum of Broken Things</div>
-  </div>
-  <div>
+  <a class="logo" href={museumBaseUrl}
+    ><Image src={logo} alt="" width="80" height="80" />
+    Museum of Broken Things
+  </a>
+  <div class="controls">
     <Search mode={searchMode} />
     <UserControls />
   </div>
@@ -33,23 +27,42 @@ const { searchMode } = Astro.props;
 
 <style>
   header {
-    align-items: center;
     display: flex;
+    align-items: center;
+    flex-direction: column;
+    gap: 1rem;
     justify-content: space-between;
     padding: 0.5rem 1.5rem;
+  }
 
-    & > div {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
+  .logo,
+  .controls {
+    display: flex;
+    align-items: center;
   }
 
   .logo {
+    color: var(--black);
     font: 2.5rem var(--title-font-family);
+    gap: 1rem;
+    text-align: center;
+    text-decoration: none;
     text-transform: uppercase;
-    & img {
-      display: block; /* avoids descender space under image */
+  }
+
+  .controls {
+    justify-content: space-evenly;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
+  @media (min-width: 60rem) {
+    header {
+      flex-direction: row;
+    }
+
+    .controls {
+      width: auto;
     }
   }
 </style>

--- a/site/src/components/Modal.astro
+++ b/site/src/components/Modal.astro
@@ -5,7 +5,7 @@
  * native can use a submit button, relying on form method="dialog".
  */
 
-import { getMode, type Mode } from "@/lib/mode";
+import { getMode } from "@/lib/mode";
 
 interface Props {
   /** Whether to close upon clicking the backdrop (affects both modes) */
@@ -14,7 +14,7 @@ interface Props {
   closeOnKeyboard?: boolean;
   id: string;
   /** Allows forcing mode, intended for cases where the fixed version is always desired */
-  mode?: Mode;
+  mode?: "fixed";
 }
 
 const { closeOnBackdrop, closeOnKeyboard, id, mode = getMode() } = Astro.props;

--- a/site/src/components/Navigation.astro
+++ b/site/src/components/Navigation.astro
@@ -131,6 +131,8 @@ const actualFailureMode = getMode() === "broken" ? failureMode : undefined;
         }
 
         & button {
+          display: flex;
+          align-items: center;
           background: none !important; /* Override all states */
           position: relative; /* Force context for z-index */
           z-index: 2; /* Avoid submenu obscuring parent item's focus outline */

--- a/site/src/components/Search.astro
+++ b/site/src/components/Search.astro
@@ -15,10 +15,8 @@ const { mode = getMode() } = Astro.props;
     <input id="search" placeholder="Search" />
   ) : (
     <form slot="fixed" role="search" action={`${museumBaseUrl}search/`}>
-      <label>
-        Search
-        <input id="search" type="search" name="query" />
-      </label>
+      <label for="search">Search</label>
+      <input id="search" type="search" name="query" />
       <button class="outline">
         <Icon name="ri:search-line" />
         <span class="visually-hidden">Search</span>
@@ -114,5 +112,10 @@ const { mode = getMode() } = Astro.props;
   input {
     padding: 0.45rem;
     width: 10rem;
+  }
+
+  label {
+    align-self: center;
+    margin-right: 1rem;
   }
 </style>

--- a/site/src/layouts/MetaLayout.astro
+++ b/site/src/layouts/MetaLayout.astro
@@ -24,7 +24,7 @@ const { title } = Astro.props;
     <title>{title} - Fixable</title>
   </head>
   <body>
-    <main id="main">
+    <main class="inset">
       <slot />
     </main>
   </body>

--- a/site/src/layouts/ShopLayout.astro
+++ b/site/src/layouts/ShopLayout.astro
@@ -2,6 +2,7 @@
 /** @fileoverview Layout for Gift Shop pages. */
 
 import { Icon } from "astro-icon/components";
+import FixableRegion from "@/components/FixableRegion.astro";
 import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
 import Navigation from "@/components/Navigation.astro";
@@ -40,6 +41,9 @@ const headerNavLinks =
     <a href={`${museumBaseUrl}gift-shop/checkout/`}>
       <span id="cart-empty"><Icon name="ri:shopping-cart-line" /></span>
       <span id="cart-filled" hidden><Icon name="ri:shopping-cart-fill" /></span>
+      <FixableRegion
+        ><span slot="fixed" class="visually-hidden">Cart</span></FixableRegion
+      >
       <span id="cart-stats"></span>
     </a>
   </Navigation>

--- a/site/src/layouts/ShopLayout.astro
+++ b/site/src/layouts/ShopLayout.astro
@@ -8,7 +8,7 @@ import Navigation from "@/components/Navigation.astro";
 import Toast from "@/components/Toast.astro";
 import { museumBaseUrl } from "@/lib/constants";
 import { getMode } from "@/lib/mode";
-import { defaultNavLinks } from "@/lib/nav-links";
+import { checkIsNavLink, defaultNavLinks } from "@/lib/nav-links";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
@@ -17,12 +17,21 @@ interface Props {
 
 const { title } = Astro.props;
 
-const headerNavLinks = [
-  ...defaultNavLinks.filter(({ name }) => name === "Gift Shop"),
-  ...defaultNavLinks.filter(({ name }) => name !== "Gift Shop"),
-];
-
 const mode = getMode();
+const headerNavLinks =
+  mode === "broken"
+    ? [
+        ...defaultNavLinks
+          .filter((entry) => entry.name === "Gift Shop")
+          .filter(checkIsNavLink)
+          // Remove mobile breakpoint classes
+          .map(({ href, name }) => ({
+            href,
+            name,
+          })),
+        ...defaultNavLinks.filter(({ name }) => name !== "Gift Shop"),
+      ]
+    : defaultNavLinks;
 ---
 
 <BaseLayout title={title}>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -439,16 +439,13 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       <dl slot="wcag2">
         <dt>1.4.3 and 1.4.6: Contrast</dt>
         <dd>
-          <ul>
-            <li>
-              On the category listing page,
-              text is superimposed over images with no overlay to guarantee minimum contrast.
-            </li>
-            <li>
-              The navigation bar content overflows its background on mobile viewports,
-              making the cart link nearly invisible.
-            </li>
-          </ul></dd>
+          On the category listing page,
+          text is superimposed over images with no overlay to guarantee minimum contrast.
+        </dd>
+        <dd>
+          The navigation bar content overflows its background on mobile viewports,
+          making the cart link nearly invisible.
+        </dd>
         <dt>1.4.13: Content on Hover or Focus</dt>
         <dd>
           In the top navigation bar, nested items open on hover and can only be dismissed by moving the pointer.
@@ -509,16 +506,12 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       <dl slot="wcag3">
         <dt>Contrast Minimum</dt>
         <dd>
-          <ul>
-            <li>
-              On the category listing page,
-              text is superimposed over images with no overlay to guarantee minimum contrast.
-            </li>
-            <li>
-              The navigation bar content overflows its background on mobile viewports,
-              making the cart link nearly invisible.
-            </li>
-          </ul>
+          On the category listing page,
+          text is superimposed over images with no overlay to guarantee minimum contrast.
+        </dd>
+        <dd>
+          The navigation bar content overflows its background on mobile viewports,
+          making the cart link nearly invisible.
         </dd>
         <dt>Allow automated entry</dt>
         <dd>
@@ -574,12 +567,8 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
           In the top navigation bar, parent items are not focusable (and therefore not openable) via keyboard.
         </dd>
         <dt>Name, Role, Value, State</dt>
-        <dd>
-          <ul>
-            <li>In the top navigation bar, there is no programmatic indication of expandable items.</li>
-            <li>The cart link contains only an icon, with no text label explaining its purpose.</li>
-          </ul>
-        </dd>
+        <dd>In the top navigation bar, there is no programmatic indication of expandable items.</dd>
+        <dd>The cart link contains only an icon, with no text label explaining its purpose.</dd>
         <dt>Consistent Navigation</dt>
         <dd>
           The Gift Shop link appears in the header on mobile viewports within gift shop pages,

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -461,6 +461,8 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           Forms in the checkout process time out after an undisclosed period of time.
         </dd>
+        <dt>2.4.6 and 2.4.9: Link Purpose</dt>
+        <dd>The cart link contains only an icon, with no text label explaining its purpose.</dd>
         <dt>3.2.3: Consistent Navigation</dt>
         <dd>
           The Gift Shop link appears in the header on mobile viewports within gift shop pages,

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -508,7 +508,18 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
 
       <dl slot="wcag3">
         <dt>Contrast Minimum</dt>
-        <dd>Text is superimposed over images with no overlay to guarantee minimum contrast.</dd>
+        <dd>
+          <ul>
+            <li>
+              On the category listing page,
+              text is superimposed over images with no overlay to guarantee minimum contrast.
+            </li>
+            <li>
+              The navigation bar content overflows its background on mobile viewports,
+              making the cart link nearly invisible.
+            </li>
+          </ul>
+        </dd>
         <dt>Allow automated entry</dt>
         <dd>
           The input fields on the payment step disallow paste.
@@ -564,7 +575,16 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         </dd>
         <dt>Name, Role, Value, State</dt>
         <dd>
-          In the top navigation bar, there is no programmatic indication of expandable items.
+          <ul>
+            <li>In the top navigation bar, there is no programmatic indication of expandable items.</li>
+            <li>The cart link contains only an icon, with no text label explaining its purpose.</li>
+          </ul>
+        </dd>
+        <dt>Consistent Navigation</dt>
+        <dd>
+          The Gift Shop link appears in the header on mobile viewports within gift shop pages,
+          but does not appear there outside of the gift shop.
+          It also does not appear in the footer on mobile.
         </dd>
         <dt>Ambiguous numerical formatting</dt>
         <dd>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -438,7 +438,17 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
 
       <dl slot="wcag2">
         <dt>1.4.3 and 1.4.6: Contrast</dt>
-        <dd>Text is superimposed over images with no overlay to guarantee minimum contrast.</dd>
+        <dd>
+          <ul>
+            <li>
+              On the category listing page,
+              text is superimposed over images with no overlay to guarantee minimum contrast.
+            </li>
+            <li>
+              The navigation bar content overflows its background on mobile viewports,
+              making the cart link nearly invisible.
+            </li>
+          </ul></dd>
         <dt>1.4.13: Content on Hover or Focus</dt>
         <dd>
           In the top navigation bar, nested items open on hover and can only be dismissed by moving the pointer.
@@ -450,6 +460,12 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dt>2.2.3: No Timing</dt>
         <dd>
           Forms in the checkout process time out after an undisclosed period of time.
+        </dd>
+        <dt>3.2.3: Consistent Navigation</dt>
+        <dd>
+          The Gift Shop link appears in the header on mobile viewports within gift shop pages,
+          but does not appear there outside of the gift shop.
+          It also does not appear in the footer on mobile.
         </dd>
         <dt>3.2.6: Consistent Help</dt>
         <dd>

--- a/site/src/pages/museum/collections/[category]/index.astro
+++ b/site/src/pages/museum/collections/[category]/index.astro
@@ -55,18 +55,17 @@ const shouldDuplicateLink =
             elsewhere.
           </p>
           <p>
-            If you are sure you would like to proceed, select a failure option
-            below.
+            If you wish to proceed, select a failure option below.
           </p>
           <div class="warning-buttons">
             <button name="submit" value="none">
-              No failures
+              None
             </button>
             <button name="submit" value="AAA">
-              Level AAA failure
+              Level AAA
             </button>
             <button name="submit" value="A">
-              Level A failure
+              Level A
             </button>
           </div>
         </div>
@@ -217,7 +216,7 @@ const shouldDuplicateLink =
 
   .warning-buttons {
     display: flex;
-    gap: calc(1rem * var(--ms8));
+    gap: 1rem;
     justify-content: center;
   }
 </style>

--- a/site/src/pages/museum/collections/index.astro
+++ b/site/src/pages/museum/collections/index.astro
@@ -8,7 +8,6 @@ import {
   checkIsNavLink,
   defaultNavLinks,
   filterNavTreeLinks,
-  type NavLink,
 } from "@/lib/nav-links";
 
 const categories = sortBy(


### PR DESCRIPTION
## Changes

- Moves "Museum of Broken Things" header text into link and removes identical alt text from image to avoid repetition
- Wraps search/sign-in below logo on mobile to avoid horizontal crunch
- Adds `white-space: nowrap` to buttons
- Updates wording in warning dialog for Homes collection to fit better on mobile
- Adds `inset` class to `main` on meta page (I think this styling was applied here at some point then got lost during earlier changes)
- Gift Shop changes:
  - Displays Gift Shop in top nav even on mobile, to increase likelihood of "off-the-end" text happening for the cart link on the right side (noted in top index)
  - Adds visually-hidden label to cart link only in fixed version; failure is noted for broken version
- Adds flex + align-items: center to fly-out buttons to improve vertical alignment of SVG (pointed out by Francis)