### PR TITLE
Add (inconsistent) help and year to footer

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -7,16 +7,17 @@ import { defaultNavLinks, type NavLink } from "@/lib/nav-links";
 
 interface Props {
   mode?: "fixed";
+  withPhoneNumber?: boolean;
 }
 
-const { mode = getMode() } = Astro.props;
+const { mode = getMode(), withPhoneNumber = true } = Astro.props;
 
 const flattenedNavLinks = defaultNavLinks.reduce((links, parentOrLink) => {
   if ("children" in parentOrLink)
     parentOrLink.children.forEach((link) => {
       // Flatten children, but skip individual collection pages
       if (!/collections\/.+/.test(link.href)) links.push(link);
-    })
+    });
   else links.push(parentOrLink);
   return links;
 }, [] as NavLink[]);
@@ -34,10 +35,18 @@ const flattenedNavLinks = defaultNavLinks.reduce((links, parentOrLink) => {
   </div>
   <div class="about">
     <Image src={logo} alt="Museum of Broken Things" width="256" height="256" />
+    {
+      mode === "broken" ? (
+        <p lang="la">MMXXIV</p>
+      ) : (
+        <p slot="fixed">Established in 2024</p>
+      )
+    }
     <p class="attribution">
-      The Museum of Broken Things is brought to you by Accessible Community and
-      W3C, with help from Unsplash and various AI chatbots.
+      Brought to you by W3C and Accessible Community, with help from Unsplash
+      and various AI chatbots.
     </p>
+    {withPhoneNumber && <p>Questions? Call us: (939) 555-0113</p>}
   </div>
 </footer>
 

--- a/site/src/layouts/ShopLayout.astro
+++ b/site/src/layouts/ShopLayout.astro
@@ -7,6 +7,7 @@ import Header from "@/components/Header.astro";
 import Navigation from "@/components/Navigation.astro";
 import Toast from "@/components/Toast.astro";
 import { museumBaseUrl } from "@/lib/constants";
+import { getMode } from "@/lib/mode";
 import { defaultNavLinks } from "@/lib/nav-links";
 import BaseLayout from "./BaseLayout.astro";
 
@@ -18,8 +19,10 @@ const { title } = Astro.props;
 
 const headerNavLinks = [
   ...defaultNavLinks.filter(({ name }) => name === "Gift Shop"),
-  ...defaultNavLinks.filter(({ name }) => name !== "Gift Shop")
+  ...defaultNavLinks.filter(({ name }) => name !== "Gift Shop"),
 ];
+
+const mode = getMode();
 ---
 
 <BaseLayout title={title}>
@@ -33,8 +36,15 @@ const headerNavLinks = [
   </Navigation>
   <main id="main" class="inset">
     <slot />
+    {
+      mode === "broken" && (
+        <p class="assistance">
+          <em>For assistance, call (939) 555-0113.</em>
+        </p>
+      )
+    }
   </main>
-  <Footer />
+  <Footer withPhoneNumber={mode === "fixed"} />
   <Toast />
 </BaseLayout>
 
@@ -46,8 +56,9 @@ const headerNavLinks = [
     const { totalCost, totalItems } = computeTotals(cart);
     document.getElementById("cart-empty")!.hidden = !!totalItems;
     document.getElementById("cart-filled")!.hidden = !totalItems;
-    document.getElementById("cart-stats")!.textContent =
-      totalItems ? `${totalItems} ($${totalCost.toFixed(2)})` : "";
+    document.getElementById("cart-stats")!.textContent = totalItems
+      ? `${totalItems} ($${totalCost.toFixed(2)})`
+      : "";
   });
 </script>
 
@@ -63,5 +74,9 @@ const headerNavLinks = [
     &:not([disabled]):active {
       background-color: var(--gray-900);
     }
+  }
+
+  .assistance {
+    margin-top: calc(1rem * var(--ms5));
   }
 </style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -444,6 +444,11 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           Forms in the checkout process time out after an undisclosed period of time.
         </dd>
+        <dt>3.2.6: Consistent Help</dt>
+        <dd>
+          The help contact number is located above the site footer,
+          as opposed to all other pages where it is inside the footer at the end.
+        </dd>
         <dt>3.3.1: Error Identification</dt>
         <dd>
           Errors do not specifically describe what expectation was failed for each field.
@@ -536,11 +541,20 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           In the top navigation bar, there is no programmatic indication of expandable items.
         </dd>
+        <dt>Ambiguous numerical formatting</dt>
+        <dd>
+          In the footer, the year of the site's creation is expressed in Roman numerals.
+        </dd>
         <dt>Numbered steps</dt>
         <dd>
           Checkout steps are not numbered; progress through the process is not indicated at all.
         </dd>
-        <dt>Contextual Help</dt>
+        <dt>Consistent help</dt>
+        <dd>
+          The help contact number is located above the site footer,
+          as opposed to all other pages where it is inside the footer at the end.
+        </dd>
+        <dt>Contextual help</dt>
         <dd>
           No contextual help is available.
         </dd>


### PR DESCRIPTION
- Adds "Established in 2024" right below the logo in the footer, except for Gift Shop pages which show the year in Roman numerals
- Adds a help contact number at the end of the footer, except for Gift Shop pages which instead have this number at the end of the main content before the footer starts