### PR TITLE
Add contrast-related failures to the CAPTCHA input

### DIFF
--- a/site/src/assets/styles/form-elements.css
+++ b/site/src/assets/styles/form-elements.css
@@ -1,5 +1,5 @@
 select, textarea,
-input:not([type="checkbox"]):not([type="file"]):not([type="image"]):not([type="radio"]):not([type="range"]) {
+input:not([type="checkbox"], [type="file"], [type="image"], [type="radio"], [type="range"]) {
   border: 1px solid var(--gray-800);
   font: inherit;
   letter-spacing: inherit;

--- a/site/src/components/FormLayout.astro
+++ b/site/src/components/FormLayout.astro
@@ -19,7 +19,7 @@ interface Props extends HTMLAttributes<"form"> {}
 
     & select,
     & textarea,
-    & input:not([type="checkbox"]):not([type="radio"]) {
+    & input:not([type="checkbox"], [type="radio"]) {
       display: block;
     }
   }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -661,6 +661,17 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>A CAPTCHA is required and no alternative is provided.</dd>
         <dt>1.4.3: Contrast (Minimum)</dt>
         <dd>Placeholder text does not meet the minimum contrast ratio.</dd>
+        <dt>1.4.11: Non-text Contrast</dt>
+        <dd>
+          The CAPTCHA field is initially empty and indicated only by a
+          low-contrast underline, making its hit area ambiguous.
+          Additionally, when focused, it has an invisible text cursor/caret.
+        </dd>
+        <dt>2.4.13: Focus Appearance</dt>
+        <dd>
+          The focused state of the CAPTCHA field only affects a 1px-thick border,
+          and does not have sufficient contrast against the unfocused state.
+        </dd>
         <dt>3.3.2: Labels or Instructions</dt>
         <dd>Form inputs have no labels.</dd>
         <dt>3.3.8 and 3.3.9: Accessible Authentication</dt>
@@ -674,6 +685,20 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>The input fields disallow paste.</dd>
         <dt>Input labels</dt>
         <dd>Form inputs have no labels.</dd>
+        <dt>Interaction indicators contrast</dt>
+        <dd>
+          The CAPTCHA field has an invisible text cursor/caret.
+        </dd>
+        <dt>Non-text contrast</dt>
+        <dd>
+          The CAPTCHA field is initially empty and indicated only by a
+          low-contrast underline, making its hit area ambiguous.
+        </dd>
+        <dt>Keyboard focus location</dt>
+        <dd>
+          The focused state of the CAPTCHA field only affects a 1px-thick border,
+          and does not have sufficient contrast against the unfocused state.
+        </dd>
       </dl>
     </MetaFailureSection>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -659,12 +659,18 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       <dl slot="wcag2">
         <dt>1.1.1: Non-text Content</dt>
         <dd>A CAPTCHA is required and no alternative is provided.</dd>
+        <dt>1.4.1: Use of Color</dt>
+        <dd>
+          The focused state of the CAPTCHA field only affects its existing border,
+          and does not have sufficient contrast against the unfocused state.
+        </dd>
         <dt>1.4.3: Contrast (Minimum)</dt>
         <dd>Placeholder text does not meet the minimum contrast ratio.</dd>
         <dt>1.4.11: Non-text Contrast</dt>
         <dd>
           The CAPTCHA field is initially empty and indicated only by a
-          low-contrast underline, making its hit area ambiguous.
+          low-contrast underline, making its interactivity hard to discover
+          and its hit area ambiguous.
           Additionally, when focused, it has an invisible text cursor/caret.
         </dd>
         <dt>2.4.13: Focus Appearance</dt>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -666,13 +666,6 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         </dd>
         <dt>1.4.3: Contrast (Minimum)</dt>
         <dd>Placeholder text does not meet the minimum contrast ratio.</dd>
-        <dt>1.4.11: Non-text Contrast</dt>
-        <dd>
-          The CAPTCHA field is initially empty and indicated only by a
-          low-contrast underline, making its interactivity hard to discover
-          and its hit area ambiguous.
-          Additionally, when focused, it has an invisible text cursor/caret.
-        </dd>
         <dt>2.4.13: Focus Appearance</dt>
         <dd>
           The focused state of the CAPTCHA field only affects a 1px-thick border,

--- a/site/src/pages/museum/register.astro
+++ b/site/src/pages/museum/register.astro
@@ -35,7 +35,7 @@ import Layout from "@/layouts/Layout.astro";
     <canvas id="captcha" width="360" height="80"></canvas>
     <label
       >Enter the letters shown above:
-      <input name="captcha" />
+      <input name="captcha" class="captcha" />
     </label>
     <button>Submit</button>
   </FormLayout>
@@ -98,3 +98,18 @@ import Layout from "@/layouts/Layout.astro";
     else persist("registration", registrationSchema.parse(result.data));
   });
 </script>
+
+<style>
+  input.captcha {
+    border: none;
+    border-bottom: 1px solid var(--gray-300);
+    caret-color: var(--white);
+    letter-spacing: 1rem;
+    width: 10rem;
+
+    &:focus {
+      border-bottom-color: var(--gray-500);
+      outline: none;
+    }
+  }
+</style>


### PR DESCRIPTION
This updates the CAPTCHA input field on the register page to only be indicated by a low-contrast underline, with the focus state additionally being low-contrast against the base style, and the text cursor/caret being completely invisible.

I reduced specificity in some common CSS to help support this.