### PR TITLE
Fail Focus Appearance on nav submenu links on Blog pages

### DIFF
--- a/site/src/components/Navigation.astro
+++ b/site/src/components/Navigation.astro
@@ -160,6 +160,14 @@ const actualFailureMode = getMode() === "broken" ? failureMode : undefined;
       }
     }
 
+    &[data-failure-mode="focus"] ul ul a {
+      border-bottom: 1px solid transparent;
+      &:focus {
+        border-color: var(--gray-100);
+        outline: none;
+      }
+    }
+
     /* Collapsed/expanded styles */
 
     &[data-failure-mode="hover"] > ul > li:not(:hover) > ul,

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -407,6 +407,13 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
         <dd>
           Each post image, as well as the arrow on the topmost post, links to its post, but has no content to describe the link.
         </dd>
+        <dt>2.4.13: Focus Appearance</dt>
+        <dd>
+          In the top nav, links within submenus indicate focus by only a single border
+          located equidistant from the text above and below it, making it ambiguous
+          which item is focused. When the last item in a submenu is focused,
+          the indicator has low contrast against the page background.
+        </dd>
         <dt>2.5.5: Target Size (Enhanced)</dt>
         <dd>
           The link after the excerpt from the topmost post is smaller than 44 by 44 pixels.


### PR DESCRIPTION
This adds styles that only apply to nav submenu links on pages with `failureMode: "focus"` (currently blog listing + post pages), to make their focus indicator only a bottom border below each link, which is both ambiguous due to equal distance between items, and low-contrast against the background when the bottom item is focused.

Note: this only updates the WCAG 2 failures under the Blog section, because the WCAG 3 section only exists in another PR. I will have to update that in whichever of the two PRs merge last.