### PR TITLE
Fix horizontal scrollbars; improve compatibility of nested selectors

### DIFF
--- a/site/src/assets/styles/content-layout.css
+++ b/site/src/assets/styles/content-layout.css
@@ -19,8 +19,8 @@
 .inset {
   max-width: var(--content-width);
   margin: 0 auto;
+}
 
-  main& {
-    padding: 1rem;
-  }
+main.inset {
+  padding: 1rem;
 }

--- a/site/src/assets/styles/content-layout.css
+++ b/site/src/assets/styles/content-layout.css
@@ -16,14 +16,11 @@
   --content-width: 75rem;
 }
 
-main.inset {
+.inset {
   max-width: var(--content-width);
   margin: 0 auto;
-  padding: 1rem;
-}
 
-/* Can be used to break out of .inset */
-.outset {
-  display: block;
-  margin: 0 calc((100% - 100vw) / 2);
+  main& {
+    padding: 1rem;
+  }
 }

--- a/site/src/components/Carousel.astro
+++ b/site/src/components/Carousel.astro
@@ -128,7 +128,7 @@ const collectionLabels = {
   }
 
   .broken {
-    .entry {
+    & :global(.entry) {
       transition: transform 1s ease-in;
       transform: translateX(100%);
 
@@ -180,7 +180,7 @@ const collectionLabels = {
   }
 
   .fixed {
-    .entry {
+    & :global(.entry) {
       transition: opacity 1s ease-in;
       opacity: 0;
 
@@ -197,7 +197,7 @@ const collectionLabels = {
       }
     }
 
-    .overline {
+    & .overline {
       letter-spacing: calc(1rem * var(--ms4));
       text-transform: uppercase;
     }

--- a/site/src/components/CookieBanner.astro
+++ b/site/src/components/CookieBanner.astro
@@ -64,11 +64,11 @@ const isBroken = getMode() === "broken";
     bottom: 0;
     left: 0;
     z-index: 9999;
+  }
 
-    dialog& {
-      max-height: 100vh;
-      overflow: auto;
-    }
+  dialog#cookie-banner {
+    max-height: 100vh;
+    overflow: auto;
   }
 
   .container {

--- a/site/src/components/FormLayout.astro
+++ b/site/src/components/FormLayout.astro
@@ -17,9 +17,9 @@ interface Props extends HTMLAttributes<"form"> {}
       margin: 1rem 0;
     }
 
-    select,
-    textarea,
-    input:not([type="checkbox"]):not([type="radio"]) {
+    & select,
+    & textarea,
+    & input:not([type="checkbox"]):not([type="radio"]) {
       display: block;
     }
   }

--- a/site/src/components/cart/CartInventory.astro
+++ b/site/src/components/cart/CartInventory.astro
@@ -42,19 +42,19 @@ const { includeRemove } = Astro.props;
 </script>
 
 <style>
-  /* Nesting is required for styles to reach programmatically-added elements */
+  /* Nest unscoped selectors to reach programmatically-added elements */
   table {
-    th,
-    td {
+    & th,
+    & :global(td) {
       padding: calc(1rem * var(--ms-5));
     }
 
-    td {
+    & :global(td) {
       border-top: 1px solid var(--hairline);
     }
 
-    th:not(:first-child),
-    td:not(:first-child) {
+    & :global(th:not(:first-child)),
+    & :global(td:not(:first-child)) {
       border-left: 1px solid var(--hairline);
       text-align: center;
     }

--- a/site/src/pages/museum/blog/[category]/[post].astro
+++ b/site/src/pages/museum/blog/[category]/[post].astro
@@ -28,7 +28,7 @@ const dateFormat = new Intl.DateTimeFormat(["en-GB"], { dateStyle: "medium" });
 <Layout headerNavFailureMode="focus" title={post.data.title} withInsetMain={false}>
   <article>
     <div
-      class="background outset"
+      class="background"
       style={{ backgroundImage: `url(${post.data.image.src})`, backgroundPosition: post.data.imagePosition }}
     >
       <header>
@@ -42,18 +42,13 @@ const dateFormat = new Intl.DateTimeFormat(["en-GB"], { dateStyle: "medium" });
         </div>
       </header>
     </div>
-    <div class="content">
+    <div class="content inset">
       <Content />
     </div>
   </article>
 </Layout>
 
 <style>
-  article {
-    max-width: var(--content-width);
-    margin: 0 auto;
-  }
-
   .background {
     background: fixed center / cover no-repeat;
     height: 50vh;

--- a/site/src/pages/museum/index.astro
+++ b/site/src/pages/museum/index.astro
@@ -23,46 +23,45 @@ const carouselEntries = [
   await getEntry("blog", "events/live-event"),
   await getEntry("exhibits", "technology/crt-monitor"),
   await getEntry("products", "vessels/water-bottle"),
-]
+];
 ---
 
-<Layout title="Home" withFixedSearch={false}>
-  <div class="outset">
-    <Carousel entries={carouselEntries} />
-  </div>
-  <h2>Explore our Collections</h2>
-  <div class="cards">
-    {
-      expandedCategories.map(({ data, slug }) => (
-        <div class="card">
-          <div class="card-image-container">
-            <CoverImage
-              src={data.topImageItem.image}
-              alt={
-                data.topImageItem.skipAlt ? null : data.topImageItem.imageDescription
-              }
-              objectPosition={data.topImageItem.imagePosition}
-              height="200"
-            />
+<Layout title="Home" withFixedSearch={false} withInsetMain={false}>
+  <Carousel entries={carouselEntries} />
+  <div class="inset">
+    <h2>Explore our Collections</h2>
+    <div class="cards">
+      {
+        expandedCategories.map(({ data, slug }) => (
+          <div class="card">
+            <div class="card-image-container">
+              <CoverImage
+                src={data.topImageItem.image}
+                alt={
+                  data.topImageItem.skipAlt
+                    ? null
+                    : data.topImageItem.imageDescription
+                }
+                objectPosition={data.topImageItem.imagePosition}
+                height="200"
+              />
+            </div>
+            <div class="card-content">
+              <h3 set:text={data.title} />
+              <div>{data.topDescription}</div>
+            </div>
+            <div class="card-footer">
+              <a class="btn btn-primary w-100" href={`collections/${slug}/`}>
+                Explore
+              </a>
+            </div>
           </div>
-          <div class="card-content">
-            <h3 set:text={data.title} />
-            <div>{data.topDescription}</div>
-          </div>
-          <div class="card-footer">
-            <a
-              class="btn btn-primary w-100"
-              href={`collections/${slug}/`}
-            >
-              Explore
-            </a>
-          </div>
-        </div>
-      ))
-    }
-  </div>
-  <div class="cards-footer">
-    <a href="collections/">Our collections &rArr;</a>
+        ))
+      }
+    </div>
+    <div class="cards-footer">
+      <a href="collections/">Our collections &rArr;</a>
+    </div>
   </div>
   <CookieBanner slot="end" />
 </Layout>
@@ -108,10 +107,6 @@ const carouselEntries = [
     background: rgb(27, 27, 27, 0.03);
     border-top: 1px solid var(--hairline);
     padding: 0.5rem;
-  }
-
-  .outset {
-    margin-top: -1rem;
   }
 </style>
 


### PR DESCRIPTION
The global `outset` styles (used on the home page and blog post pages) caused a problem on user agents with discrete scrollbars (i.e. scrollbars that occupy width/height as opposed to being overlaid) due to using `calc(100% - 100vw)`. This PR uses alternative means to accomplish the full-width backgrounds used on these pages. (The diff for `pages/museum/index.astro` will be easier to read with `?w=1` to ignore whitespace.)

While I was working on this, I noticed an instance of a nested selector not working in Safari 16 (due to not starting with a symbol), and I knew there were likely a few other instances of this across the codebase, so I resolved all that I found (most visibly affecting login/shop/volunteer forms and the cart inventory page in checkout).