### PR TITLE
Don't hard-code base URL in Video component

### DIFF
--- a/site/src/components/Video.astro
+++ b/site/src/components/Video.astro
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const { src: filename, backdrop = false } = Astro.props;
-const src = `/fixable/assets/videos/${filename}`;
+const src = `${import.meta.env.BASE_URL}assets/videos/${filename}`;
 const extension = filename.slice(filename.lastIndexOf(".") + 1);
 const type = `video/${extension}`;
 
@@ -35,6 +35,11 @@ const videoAttributes = backdrop
 </div>
 
 <style>
+  video {
+    height: 100%;
+    width: 100%;
+  }
+
   .video-wrapper {
     height: 50vh;
     position: relative;
@@ -44,8 +49,6 @@ const videoAttributes = backdrop
       object-fit: cover;
       object-position: center;
       position: absolute;
-      height: 100%;
-      width: 100%;
     }
   }
 </style>

--- a/site/src/pages/museum/index.astro
+++ b/site/src/pages/museum/index.astro
@@ -65,7 +65,7 @@ const carouselEntries = [
     </div>
   </div>
 
-  <h2>Coming soon: Our homes exhibit.</h2>
+  <h2 class="inset">Coming soon: Our homes exhibit.</h2>
   <Video backdrop src="exhibit-landscape.mp4" />
   <CookieBanner slot="end" />
 </Layout>


### PR DESCRIPTION
This fixes 3 things:

- Replaces hard-coded `/fixable/` with `import.meta.env.BASE_URL` (which I should have thought of when reviewing #70); this has no effect on this repository but will fix the videos on the W3C version
- Restores original placement of width/height styles in Video component (this was my mistake during cleanup, which caused an issue on the Tour page)
- Insets the heading added to the home page (a change related to another PR that merged between when the Video PR opened and was merged)