### PR TITLE
Address meta page and early home computers page issues

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -11,7 +11,6 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
       This site is designed to demonstrate a wide range of accessibility
       failures, for teaching and assessment purposes.
     </p>
-    <p>This page summarizes the accessibility issues from WCAG 2 and WCAG 3 for each section of the site. 
     <p>
       <strong>Reminder:</strong> This site is an example only.
       The contents are made up and it does not perform real sign-in or payment processing.
@@ -21,13 +20,16 @@ import MetaLayout from "@/layouts/MetaLayout.astro";
     <p>
       (The site also does not actually store cookies, despite what the home page might suggest.)
     </p>
+    <p>
+      <a href="museum/">Visit the Museum of Broken Things</a>
+    </p>
   </section>
 
   { /* Hide summary for built version at the moment; show in dev for confirming content */ }
   <section id="summary-of-failures" hidden={import.meta.env.PROD || undefined}>
     <h2>Summary of failures</h2>
     <p>
-      This section provides a breakdown of failures, organized by sections of the site.
+      This section provides a breakdown of WCAG 2 and WCAG 3 failures, organized by sections of the site.
     </p>
 
     {

--- a/site/src/pages/museum/early-home-computers-event.astro
+++ b/site/src/pages/museum/early-home-computers-event.astro
@@ -9,7 +9,7 @@ import vic20 from "@/assets/images/exhibits/early-home-computers/vic20.webp";
 ---
 
 <Layout title="Special PC event">
-  <header class="page">
+  <header>
     <h1>Early Home Computers Event!</h1>
   </header>
 
@@ -264,7 +264,7 @@ import vic20 from "@/assets/images/exhibits/early-home-computers/vic20.webp";
   devices.addEventListener("click", toggleReadMore);
 </script>
 
-<style is:global>
+<style is:global is:inline>
   :root {
     --actual-black-not-like-that-other-black:black;
     scrollbar-color: hsl(0, 0%, 20%) var(--actual-black-not-like-that-other-black);
@@ -293,17 +293,19 @@ import vic20 from "@/assets/images/exhibits/early-home-computers/vic20.webp";
   header {
     color: var(--black);
   }
+</style>
 
-  header.page {
+<style>
+  header {
     background: var(--actual-black-not-like-that-other-black);
     container: hd1 / inline-size;
     grid-column: 1 / -1;
   }
 
-  @media(width <= 750px){
-    header.page{
-      position:sticky;
-      top:0;
+  @media (width <= 750px) {
+    header {
+      position: sticky;
+      top: 0;
       z-index: 2;
     }
   }
@@ -432,12 +434,12 @@ import vic20 from "@/assets/images/exhibits/early-home-computers/vic20.webp";
       font-style: italic;
       margin-block-end: calc(var(--ms0) * 1em);
       padding: calc(var(--ms-6) * 1em) 0;
-      & a{
+      & a {
         @supports (text-decoration-color: hsl(from red h s calc(l - 5%))) {
         text-decoration-color: hsl(from var(--red-warm-600) h s calc(l - 5%));
         }
         text-decoration-color: hsl(from var(--red-warm-600) h s calc(l - 5));
-        text-decoration-thickness:0.25em;
+        text-decoration-thickness: 0.25em;
       }
     }
     & .initial p::first-line {
@@ -447,20 +449,17 @@ import vic20 from "@/assets/images/exhibits/early-home-computers/vic20.webp";
     & .more:focus {
       box-shadow: none;
     }
-    &.full-cover{
+    &.full-cover {
       position: relative;
-      & a::after{
+      & a::after {
         content:"";
         position: absolute;
-        bottom:0;
-        left:0;
-        right:0;
-        top:0;
+        inset: 0;
       }
-      & a:focus-visible{
+      & a:focus-visible {
         box-shadow: none;
       }
-      &:focus-within{
+      &:focus-within {
         box-shadow:
         0 0 0 2px white,
         0 0 0 4px blue;


### PR DESCRIPTION
These issues were flagged by @fstrr.

Meta page changes:

- Adds a link to the museum home page in the top section (which is always displayed)
- Removes a redundant paragraph from the top section that wouldn't make sense without the failures section, working whatever unique information it had into the top paragraph inside the failures section

Early home computers event page changes:

- Split styles into 2 sections: one with `is:global is:inline` for only the styles that need to appear last to override global CSS from Layout, and the other with neither flag for styles that can be scoped and bundled/optimized
  - Relatedly, this allows removing the `page` class from `header` since its styles are now automatically scoped
- Fixed formatting; shortened top/right/bottom/left 0 to inset 0