### PR TITLE
Extend form timeouts from 30s to 60s

### DIFF
--- a/site/src/pages/museum/gift-shop/checkout/payment.astro
+++ b/site/src/pages/museum/gift-shop/checkout/payment.astro
@@ -77,7 +77,7 @@ import ShopLayout from "@/layouts/ShopLayout.astro";
       withDismiss: false,
     });
     disableInputs(document.querySelector("main form") as HTMLFormElement);
-  }, 30000);
+  }, 60000);
 </script>
 
 <style>

--- a/site/src/pages/museum/gift-shop/checkout/shipping.astro
+++ b/site/src/pages/museum/gift-shop/checkout/shipping.astro
@@ -67,7 +67,7 @@ import ShopLayout from "@/layouts/ShopLayout.astro";
       withDismiss: false,
     });
     disableInputs(document.querySelector("main form") as HTMLFormElement);
-  }, 30000);
+  }, 60000);
 </script>
 
 <style>

--- a/site/src/pages/museum/volunteer/index.astro
+++ b/site/src/pages/museum/volunteer/index.astro
@@ -41,5 +41,5 @@ import Layout from "@/layouts/Layout.astro";
       withDismiss: false,
     });
     disableInputs(document.querySelector("main form") as HTMLFormElement);
-  }, 30000);
+  }, 60000);
 </script>


### PR DESCRIPTION
This extends the timeouts on the volunteer form and the checkout forms (shipping / payment) to 60 seconds.