### PR TITLE
Toast: Fix action to not break future toasts; improve fixed version

### DIFF
--- a/site/src/components/Toast.astro
+++ b/site/src/components/Toast.astro
@@ -10,8 +10,8 @@ import { getMode } from "@/lib/mode";
 import { Icon } from "astro-icon/components";
 
 const iconMap = {
-  error: "ri:error-warning-fill",
-  info: "ri:information-2-fill",
+  error: "ri:error-warning-line",
+  info: "ri:information-2-line",
 } as const;
 // Expose ToastType from here for use by API in toast.ts
 export type ToastType = keyof typeof iconMap;
@@ -26,10 +26,8 @@ export type ToastType = keyof typeof iconMap;
       </div>
     ) : (
       <dialog id="toast">
-        <form method="dialog">
-          <div id="toast-content" />
-          <button id="toast-dismiss">Dismiss</button>
-        </form>
+        <div id="toast-content" />
+        <button id="toast-dismiss">Dismiss</button>
       </dialog>
     )
   }
@@ -45,11 +43,10 @@ export type ToastType = keyof typeof iconMap;
 
 <script>
   import { hideToast } from "@/lib/client/toast";
-  import { getMode } from "@/lib/mode";
 
   // Dismiss needs to be explicitly handled in non-dialog case
   const dismissEl = document.getElementById("toast-dismiss")!;
-  if (getMode() === "broken") dismissEl.addEventListener("click", hideToast);
+  dismissEl.addEventListener("click", hideToast);
 </script>
 
 <style>
@@ -71,7 +68,10 @@ export type ToastType = keyof typeof iconMap;
     color: var(--gray-050);
     max-width: 90vw;
     opacity: 0;
-    transition: opacity 250ms, transform 250ms;
+    position: static; /* Override dialog to rely on container style */
+    transition:
+      opacity 250ms,
+      transform 250ms;
     transform: translateY(50%);
 
     & :global(a) {
@@ -88,27 +88,22 @@ export type ToastType = keyof typeof iconMap;
     height: 2rem;
     width: 2rem;
   }
-  svg[data-icon="ri:error-warning-fill"] {
+  svg[data-icon="ri:error-warning-line"] {
     color: var(--red-warm-400);
   }
-  svg[data-icon="ri:information-2-fill"] {
+  svg[data-icon="ri:information-2-line"] {
     color: var(--blue-400);
   }
 
-  div#toast,
-  #toast form {
+  #toast {
     display: flex;
-    gap: calc(1rem * var(--ms5)); /* Between content and dismiss button */
+    gap: 1rem; /* Between content and dismiss button */
     padding: 1rem;
 
-    & button {
+    & :global(button) {
       border-radius: 4px;
       padding-block: 0.25rem;
     }
-  }
-
-  dialog#toast {
-    padding: 0;
   }
 
   #toast-content {

--- a/site/src/lib/client/toast.ts
+++ b/site/src/lib/client/toast.ts
@@ -48,7 +48,8 @@ function createTransitionPromise(el: HTMLElement) {
  * This is exposed for the Toast component; direct calls should be unnecessary.
  */
 export async function hideToast() {
-  await toastTransitionPromise; // Wait for any existing transition to finish first
+  // Wait for any existing transition to finish first
+  if (toastTransitionPromise) await toastTransitionPromise;
   const toastEl = document.getElementById("toast")!;
   if (toastEl.classList.contains("showing")) {
     toastEl.classList.remove("showing");
@@ -108,15 +109,10 @@ export async function showToast(
     const isButton = "actionCallback" in actionOptions;
     const el = document.createElement(isButton ? "button" : "a");
     if (isButton) {
-      el.addEventListener(
-        "click",
-        isBroken
-          ? () => {
-              toastEl.hidden = true;
-              actionOptions.actionCallback();
-            }
-          : actionOptions.actionCallback
-      );
+      el.addEventListener("click", async () => {
+        await hideToast();
+        actionOptions.actionCallback();
+      });
     } else {
       (el as HTMLAnchorElement).href = actionOptions.actionHref;
     }
@@ -127,7 +123,7 @@ export async function showToast(
 
   if (isBroken) toastEl.hidden = false;
   else (toastEl as HTMLDialogElement).show();
-  
+
   // Give element a chance to paint before adding class, to apply transition
   setTimeout(() => toastEl.classList.add("showing"), 15);
   await createTransitionPromise(toastEl);


### PR DESCRIPTION
This addresses a critical functionality bug, and another potential unintended usability snag in the Toast component, plus includes some fixes/improvements for the fixed version of the component.

- Conditionalizes awaiting `toastTransitionPromise` to avoid incurring a race condition when consecutively hiding then performing an action that shows a new toast; previously, this would close the first toast but then break the component's state, preventing any future toasts from displaying. (Thanks @julierawe for spotting this!)
- Switches the icons from filled to outlined versions, to attempt to make it more clear that they're not interactable
- Removes `form method="dialog"` from fixed version of component so that more of the existing code paths (and transitions) work identically between both the broken and fixed versions
- Fix inconsistent styles between dismiss and action button (needs to use a global selector due to client-side DOM cloning)