### PR TITLE
Fix collection and gift shop links in carousel

### DIFF
--- a/site/src/components/Carousel.astro
+++ b/site/src/components/Carousel.astro
@@ -15,10 +15,19 @@ type ImageEntry =
 
 const { entries } = Astro.props;
 
-const collectionLabels = {
-  blog: "Post",
-  exhibits: "Exhibit",
-  products: "Merch",
+const collectionMap = {
+  blog: {
+    label: "Post",
+    path: "blog",
+  },
+  exhibits: {
+    label: "Exhibit",
+    path: "collections",
+  },
+  products: {
+    label: "Merch",
+    path: "gift-shop"
+  },
 };
 ---
 
@@ -32,14 +41,14 @@ const collectionLabels = {
       >
         <FixableRegion>
           <div class="overline">L A T E S T &nbsp; {
-            collectionLabels[entry.collection].toUpperCase().split("").join(" ")
+            collectionMap[entry.collection].label.toUpperCase().split("").join(" ")
           }</div>
-          <div slot="fixed" class="overline">Latest {collectionLabels[entry.collection]}</div>
+          <div slot="fixed" class="overline">Latest {collectionMap[entry.collection].label}</div>
         </FixableRegion>
         <div class="title">{entry.data.title}</div>
         <a
           class="button"
-          href={`${museumBaseUrl}${entry.collection}/${entry.id}/`}
+          href={`${museumBaseUrl}${collectionMap[entry.collection].path}/${entry.id}/`}
         >
           Read more
         </a>


### PR DESCRIPTION
I realized that the links to the CRT monitor and water bottle pages in the carousel on the home page have been broken, probably for quite a long time. I'm pretty sure that was unintentional, so this adds logic to adjust the URL paths, which were previously naively based on the collection names.

How to reproduce: go to the museum homepage, wait for the carousel to advance to the 2nd and 3rd items, and click the read more link on each. They previously 404'd.