### PR TITLE
Revamp Volunteer form; move old fields to Register

### DIFF
--- a/site/src/components/FormLayout.astro
+++ b/site/src/components/FormLayout.astro
@@ -22,5 +22,9 @@ interface Props extends HTMLAttributes<"form"> {}
     & input:not([type="checkbox"], [type="radio"]) {
       display: block;
     }
+
+    & textarea {
+      width: 100%;
+    }
   }
 </style>

--- a/site/src/lib/client/form.ts
+++ b/site/src/lib/client/form.ts
@@ -2,7 +2,7 @@ import type { ZodObject, ZodRawShape } from "astro/zod";
 
 /** Utility function for failure cases that disables all inputs/buttons in a form. */
 export function disableInputs(form: HTMLFormElement) {
-  const inputSelectors = ["input", "select", "button"] as const;
+  const inputSelectors = ["input", "select", "textarea", "button"] as const;
   inputSelectors.forEach((selector) =>
     form.querySelectorAll(selector).forEach((el) => (el.disabled = true))
   );

--- a/site/src/lib/client/store.ts
+++ b/site/src/lib/client/store.ts
@@ -23,8 +23,12 @@ export const storeSchema = z.object({
   hasDismissedCookieBanner: z.boolean().default(false),
   loggedInAt: z.string().datetime().nullable().default(null),
   registration: z.object({
+    firstName: z.string().min(1),
+    middleName: z.string().optional(),
+    lastName: z.string().min(1),
     email: z.string().email(),
     password: z.string().min(1),
+    phone: z.string().regex(/^[\d -]+$/),
   }).nullable().default(null),
 });
 export type Store = z.infer<typeof storeSchema>;

--- a/site/src/pages/museum/register.astro
+++ b/site/src/pages/museum/register.astro
@@ -19,12 +19,56 @@ import Layout from "@/layouts/Layout.astro";
       fixed={{ role: "alert", tabindex: -1 }}
     />
     <label
-      >Display Name
-      <input name="displayName" />
+      >First name
+      <input name="firstName" />
+    </label>
+    <label
+      >Middle name
+      <input name="middleName" />
+    </label>
+    <label
+      >Last name
+      <input name="lastName" />
     </label>
     <label
       >Email Address
-      <input type="email" name="email" />
+      <Fixable
+        as="input"
+        broken={{ type: "text" }}
+        fixed={{ type: "email", "aria-describedby": "email-suggestion" }}
+        name="email"
+        id="email"
+      />
+    </label>
+    {
+      /**
+       * @break
+       * wcag2:
+       *   - 1.4.3
+       *   - 1.4.6
+       * wcag3: Text contrast sufficient (minimum)
+       * description: |
+       *   The "did you mean" email prompt has insufficient contrast.
+       */
+      /**
+       * @break
+       * wcag2: 4.1.3
+       * wcag3: Error notifications available
+       * description: |
+       *   The "did you mean" email prompt doesn't grab focus and isn't announced.
+       * discussionItems:
+       *   - The message this displays can be confusing/misleading; does that fail any SC/requirement?
+       */
+    }
+    <Fixable
+      as="div"
+      broken={{ class: "email-did-you-mean__broken" }}
+      fixed={{ class: "email-did-you-mean__fixed", role: "alert" }}
+      id="email-suggestion"
+    />
+    <label
+      >Phone number
+      <Fixable as="input" fixed={{ type: "tel" }} name="phone" />
     </label>
     <label
       >Password
@@ -53,6 +97,13 @@ import Layout from "@/layouts/Layout.astro";
        * description: A cognitive test is present on the Register page.
        */
     }
+    <Fixable
+      as="p"
+      id="captcha-error"
+      class="error"
+      hidden
+      fixed={{ role: "alert", tabindex: -1 }}
+    />
     <canvas id="captcha" width="360" height="80"></canvas>
     {
       /**
@@ -119,6 +170,9 @@ import Layout from "@/layouts/Layout.astro";
   });
 
   const errorEl = document.getElementById("error") as HTMLParagraphElement;
+  const captchaErrorEl = document.getElementById(
+    "captcha-error"
+  ) as HTMLParagraphElement;
   const form = document.querySelector("main form") as HTMLFormElement;
   form.addEventListener("submit", (event) => {
     const codeText = codeLetters.join("");
@@ -129,26 +183,56 @@ import Layout from "@/layouts/Layout.astro";
     const result = validateInputs(
       form,
       registrationSchema.extend({
-        displayName: z.string().min(1),
         "password-confirm": z
           .string()
           .min(1)
           .refine((value) => value === form.elements["password"].value),
-        captcha: z.string().refine((value) => value.toUpperCase() === codeText),
       })
     );
 
     if (!result.success) {
       event.preventDefault();
       errorEl.textContent =
-        "All fields are required and the password fields must match.";
+        "All fields except Middle Name are required, and the password fields must match.";
       errorEl.hidden = false;
 
       if (getMode() === "fixed") errorEl.focus();
     }
 
+    const captchaResult = validateInputs(
+      form,
+      z.object({
+        captcha: z.string().refine((value) => value.toUpperCase() === codeText),
+      })
+    );
+    if (!captchaResult.success) {
+      event.preventDefault();
+      captchaErrorEl.textContent =
+        "The text you entered does not match the letters in the image; try again.";
+      captchaErrorEl.hidden = false;
+
+      if (getMode() === "fixed") captchaErrorEl.focus();
+    }
+
     // Re-parse to strip fields that shouldn't persist
     else persist("registration", registrationSchema.parse(result.data));
+  });
+
+  document.getElementById("email")!.addEventListener("blur", function () {
+    const email = (this as HTMLInputElement).value || "";
+    const suggestion = document.getElementById("email-suggestion")!;
+    if (
+      email &&
+      email.includes("@") &&
+      !email.endsWith("@gmail.com") &&
+      !email.endsWith("@hotmail.com")
+    ) {
+      suggestion.style.display = "block";
+      suggestion.textContent = "Did you mean gmail.com or hotmail.com?";
+    } else {
+      suggestion.style.display = "";
+      suggestion.textContent = "";
+    }
   });
 </script>
 
@@ -164,5 +248,18 @@ import Layout from "@/layouts/Layout.astro";
       border-bottom-color: var(--gray-500);
       outline: none;
     }
+  }
+
+  #email-suggestion {
+    display: none;
+    margin-block-start: -1rem;
+  }
+
+  .email-did-you-mean__broken {
+    color: var(--red-warm-400);
+  }
+
+  .email-did-you-mean__fixed {
+    color: var(--red-warm-500);
   }
 </style>

--- a/site/src/pages/museum/volunteer/index.astro
+++ b/site/src/pages/museum/volunteer/index.astro
@@ -1,142 +1,169 @@
 ---
-import Fixable from "@/components/Fixable.astro";
+import ConditionalParent from "@/components/ConditionalParent.astro";
+import FixableRegion from "@/components/FixableRegion.astro";
 import FormLayout from "@/components/FormLayout.astro";
 import Layout from "@/layouts/Layout.astro";
+import { getMode } from "@/lib/mode";
+
+const isBroken = getMode() === "broken";
 
 /** @breaklocation Volunteer */
 /** @breakprocess volunteering */
 ---
 
 <Layout title="Volunteer">
-  <FormLayout action="thank-you/">
-    <label
-      >First name
-      <input name="firstname" />
-    </label>
-    <label
-      >Middle name
-      <input name="middlename" />
-    </label>
-    <label
-      >Last name
-      <input name="lastname" />
-    </label>
-    <label
-      >Email address
-      <Fixable
-        as="input"
-        broken={{ type: "text" }}
-        fixed={{ type: "email", "aria-describedby": "email-suggestion" }}
-        name="email"
-        id="email"
-      />
-    </label>
+  <h1>Thank You to our Volunteers</h1>
+  <p>
+    The Museum would not be where it is today without the generous help of a
+    wide variety of volunteers. We are grateful to everyone who has contributed
+    in any way, and we're incredibly proud of all we've accomplished together.
+  </p>
+  <p id="sign-in-cta" hidden>
+    Interested in volunteering? Please <a href="../login/">sign in</a> to apply.
+  </p>
+  <FormLayout id="volunteer-form" action="thank-you/" hidden>
+    <p>
+      If you are interested in volunteering, please fill out the form below.
+    </p>
+    <h2>Volunteer Application Form</h2>
+    <ConditionalParent as="div" class="fieldset" role="group" if={isBroken}>
+      <ConditionalParent as="fieldset" if={!isBroken}>
+        <FixableRegion>
+          <div id="days-of-week">Days of week available:</div>
+          <legend slot="fixed">Days of week available</legend>
+        </FixableRegion>
+        {
+          [
+            "Sunday",
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+          ].map((day, i) => (
+            <>
+              <input type="checkbox" name="days" id={`days-${i}`} value={i} />
+              <label for={`days-${i}`}>{day}</label>
+            </>
+          ))
+        }
+      </ConditionalParent>
+    </ConditionalParent>
     {
       /**
        * @break
-       * wcag2:
-       *   - 1.4.3
-       *   - 1.4.6
-       * wcag3: Text contrast sufficient (minimum)
-       * description: |
-       *   The "did you mean" email prompt has insufficient contrast.
-       */
-      /**
-       * @break
-       * wcag2: 4.1.3
-       * wcag3: Error notifications available
-       * description: |
-       *   The "did you mean" email prompt doesn't grab focus and isn't announced.
+       * wcag2: 1.3.1
+       * wcag3: Relationships detectable
+       * description: The `aria-labelledby` attribute points to the wrong field.
+       * discussionItems:
+       *   - Do cases where no label or no group role is set also fail this or another SC/requirement?
        */
     }
-    <Fixable
+    <ConditionalParent
       as="div"
-      broken={{ class: "email-did-you-mean__broken" }}
-      fixed={{ class: "email-did-you-mean__fixed", role: "alert" }}
-      id="email-suggestion"
-    />
-    <label
-      >Phone number
-      <Fixable as="input" fixed={{ type: "tel" }} name="phone" />
-    </label>
+      class="fieldset"
+      role="group"
+      aria-labelledby="days-of-week"
+      if={isBroken}
+    >
+      <ConditionalParent as="fieldset" if={!isBroken}>
+        <FixableRegion>
+          <div>Times of day available:</div>
+          <legend slot="fixed">Times of day available</legend>
+        </FixableRegion>
+        {
+          ["Morning", "Afternoon", "Evening"].map((time) => (
+            <>
+              <input
+                type="checkbox"
+                name="times"
+                id={`times-${time.toLowerCase()}`}
+                value={time.toLowerCase()}
+              />
+              <label for={`times-${time.toLowerCase()}`}>{time}</label>
+            </>
+          ))
+        }
+      </ConditionalParent>
+    </ConditionalParent>
+    <ConditionalParent as="div" class="fieldset" if={isBroken}>
+      <ConditionalParent as="fieldset" if={!isBroken}>
+        <FixableRegion>
+          <div>Positions of interest:</div>
+          <legend slot="fixed">Positions of interest</legend>
+        </FixableRegion>
+        <input
+          type="checkbox"
+          name="positions"
+          id="positions-docent"
+          value="docent"
+        />
+        <label for="positions-docent">
+          Docent (requires 60 hours of training)</label
+        >
+        <input
+          type="checkbox"
+          name="positions"
+          id="positions-information-desk"
+          value="information-desk"
+        />
+        <label for="positions-information-desk"> Information Desk</label>
+        <input
+          type="checkbox"
+          name="positions"
+          id="positions-alt"
+          value="alt"
+        />
+        <label for="positions-alt"
+          >Crowdsource alt text for collection images (remote)</label
+        >
+        <div>
+          <input
+            type="checkbox"
+            name="positions"
+            id="positions-other"
+            value="other"
+          />
+          <label for="positions-other">Other (explain expertise)</label>
+          {
+            /**
+             * @break
+             * wcag2: 4.1.2
+             * wcag3: Roles, values, states, properties available
+             * description: The "Other" textarea has no label.
+             */
+            /**
+             * @break
+             * wcag3: Changes to elements notified
+             * description: |
+             *   The "Other" textarea only appears when the "Other (explain expertise)" checkbox is checked.
+             *   This change is not announced.
+             */
+          }
+          <textarea name="positions-other"></textarea>
+        </div>
+      </ConditionalParent>
+    </ConditionalParent>
     <button type="submit">Submit</button>
   </FormLayout>
 </Layout>
-<style>
-  #email-suggestion {
-    display: none;
-    margin-block-start: -1rem;
-  }
-
-  .email-did-you-mean__broken {
-    color: var(--red-warm-400);
-  }
-
-  .email-did-you-mean__fixed {
-    color: var(--red-warm-500);
-  }
-</style>
 
 <script>
-  import { disableInputs } from "@/lib/client/form";
-  import { showToast } from "@/lib/client/toast";
+  import { recall } from "@/lib/client/store";
 
-  /**
-   * @break
-   * wcag2: 2.2.3
-   * wcag3: Timeout adjustable
-   * description: |
-   *   The toast that appears when the timeout lapses disappears after a few seconds,
-   *   and this cannot be prevented.
-   */
-  /**
-   * @break
-   * wcag2: 2.2.6
-   * wcag3:
-   *   - No time limits
-   *   - Time limits conveyed
-   * description: |
-   *   The form becomes unsubmittable after a short time period,
-   *   which is not disclosed in advance and cannot be adjusted or disabled.
-   */
-  setTimeout(() => {
-    /**
-     * @break
-     * wcag2: 4.1.3
-     * wcag3: Error notifications available
-     * description: |
-     *   When the form times out, the toast that appears
-     *   does not grab focus and is not announced.
-     */
-    /**
-     * @break
-     * wcag3: Error messages persistent
-     * description: |
-     *   The timeout notification toast dismisses itself automatically
-     *   without waiting for the user.
-     */
-    showToast("The form has expired; please refresh the page to start over.", {
-      duration: 3000,
-      type: "error",
-      withDismiss: false,
-    });
-    disableInputs(document.querySelector("main form") as HTMLFormElement);
-  }, 60000);
-
-  document.getElementById("email")!.addEventListener("blur", function () {
-    const email = (this as HTMLInputElement).value || "";
-    const suggestion = document.getElementById("email-suggestion")!;
-    if (
-      email &&
-      email.includes("@") &&
-      !email.endsWith("@gmail.com") &&
-      !email.endsWith("@hotmail.com")
-    ) {
-      suggestion.style.display = "block";
-      suggestion.textContent = "Did you mean gmail.com or hotmail.com?";
-    } else {
-      suggestion.style.display = "";
-      suggestion.textContent = "";
-    }
-  });
+  if (recall("loggedInAt"))
+    document.getElementById("volunteer-form")!.hidden = false;
+  else document.getElementById("sign-in-cta")!.hidden = false;
 </script>
+
+<style>
+  input[value="other"]:not(:checked) ~ textarea[name="positions-other"] {
+    display: none;
+  }
+
+  fieldset label,
+  .fieldset label {
+    margin-inline-end: 1em;
+  }
+</style>


### PR DESCRIPTION
This PR makes the following changes:

- Moves existing fields from volunteer form into registration form
  - This includes adding validation for those fields and relocating #87
- Adds an extra error region to the registration form near the captcha field, since the form is now likely to span more than a single viewport height
- Implements new fields (checkbox groups) for volunteer form
- Only displays volunteer form when signed in; otherwise, links to sign in page
- Based on further discussion below, removes the timeout from the volunteer form

New breaks intentionally introduced in this PR:

- The checkbox groups in the volunteer form are not described correctly:
  - One uses `role="group"` with `aria-labelledby`, but pointing to the wrong element from a different group
  - One uses `role="group"` with no `aria-labelledby`
  - One does not set `role` at all
  - Discussion item: When we first discussed adding this, it was mentioned that only the first of the three above cases would explicitly fail WCAG 2 (1.3.1 Info and Relationships); should WCAG 3 more clearly cause the remaining two cases to fail?
- The "other" textarea only displays when "other" is checked, with no announcement or label
  - Discussion item: what would be the optimal correct behavior for this?
    - Always displaying the field comes with its own potential snags, e.g. if someone writes in the textbox should it automatically check the "Other" checkbox if it's not checked, and then does that need to be announced anyway, vs. showing/hiding the textarea based on the checkbox state and announcing it?