### PR TITLE
Middleware: Don't apply HTML transformations to non-HTML responses

### DIFF
--- a/site/src/middleware.ts
+++ b/site/src/middleware.ts
@@ -9,6 +9,8 @@ import GithubSlugger from "github-slugger";
  */
 const addHeadingIds: MiddlewareHandler = async (_, next) => {
   const response = await next();
+  if (response.headers.get("Content-Type") !== "text/html") return response;
+
   const $ = load(await response.text());
   const slugger = new GithubSlugger();
 

--- a/site/src/pages/museum/api/search.ts
+++ b/site/src/pages/museum/api/search.ts
@@ -30,5 +30,7 @@ export const GET: APIRoute = async () => {
       });
   }
 
-  return new Response(JSON.stringify(pageResults));
+  return new Response(JSON.stringify(pageResults), {
+    headers: { "Content-Type": "application/json" },
+  });
 };


### PR DESCRIPTION
This fixes a regression I noticed this week, caused by #95, affecting the search feature.

When I added middleware, I applied it to all responses. This has the effect of mangling non-HTML responses, because the middleware passes the response body through Cheerio. Cheerio's default behavior is to expect a full document, and to wrap the content in `html` and `body` tags if it isn't already.

This PR adds a check to leave the response alone if it is not `text/html`. It also adds an explicit `application/json` type to the `/api/search` endpoint, though this is not critical to the fix (it reported `text/plain` before).

The bug was plainly visible in dev tools, as it resulted in an error in the log about failing to parse JSON.